### PR TITLE
Include extended asset loader android

### DIFF
--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -125,7 +125,9 @@ class ModelViewer(
         view.camera = camera
 
         materialProvider = UbershaderProvider(engine)
-        assetLoader = AssetLoader(engine, materialProvider, EntityManager.get())
+        // Just pass in an empty string, see https://github.com/google/filament/issues/7905#issuecomment-2161779784,
+        // to opt for the extended asset loader until https://github.com/google/filament/issues/7782 is done
+        assetLoader = AssetLoader(engine, materialProvider, EntityManager.get(), "")
         resourceLoader = ResourceLoader(engine, normalizeSkinningWeights)
 
         // Always add a direct light source since it is required for shadowing.

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
@@ -103,6 +103,25 @@ public class AssetLoader {
         mMaterialCache = provider;
     }
 
+    public AssetLoader(@NonNull Engine engine, @NonNull MaterialProvider provider,
+                       @NonNull EntityManager entities, String filePath) {
+
+        long nativeEngine = engine.getNativeObject();
+        long nativeEntities = entities.getNativeObject();
+        if (filePath == null) {
+            mNativeObject = nCreateAssetLoader(nativeEngine, provider, nativeEntities);
+        } else {
+            mNativeObject = nCreateAssetLoaderExtended(nativeEngine, provider, nativeEntities, filePath);
+        }
+
+        if (mNativeObject == 0) {
+            throw new IllegalStateException("Unable to parse glTF asset.");
+        }
+
+        mEngine = engine;
+        mMaterialCache = provider;
+    }
+
     /**
      * Frees all memory consumed by the native <code>AssetLoader</code>
      *
@@ -190,6 +209,8 @@ public class AssetLoader {
 
     private static native long nCreateAssetLoader(long nativeEngine, Object provider,
             long nativeEntities);
+    private static native long nCreateAssetLoaderExtended(long nativeEngine, Object provider,
+                                                          long nativeEntities, String filePath);
     private static native void nDestroyAssetLoader(long nativeLoader);
     private static native long nCreateAsset(long nativeLoader, Buffer buffer, int remaining);
     private static native long nCreateInstancedAsset(long nativeLoader, Buffer buffer, int remaining,

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -1588,8 +1588,10 @@ void FAssetLoader::importSkins(FFilamentInstance* instance, const cgltf_data* gl
     }
 }
 
+// Including support for Android
+// See https://github.com/google/filament/discussions/7851#discussioncomment-9453369
 bool AssetConfigurationExtended::isSupported() {
-#if defined(__ANDROID__) || defined(IOS) || defined(__EMSCRIPTEN__)
+#if defined(IOS) || defined(__EMSCRIPTEN__)
     return false;
 #else
     return true;


### PR DESCRIPTION
If the normals aren't exported in the GLB model then Filament wasn't generating them properly when the vertices in the model are shared by triangles.  [This](https://github.com/google/filament/pull/7776) PR fixes that issue but is available only for desktop for [this](https://github.com/google/filament/discussions/7851#discussioncomment-9453369) reason (tbh honest i don't quite understand that comment - i din't have to make any changes in ResourceLoader) so I just lifted the restriction on Android platform which seem to work

Some background for this issue,
https://github.com/google/filament/discussions/7851
https://github.com/google/filament/issues/6358

Without extended loader | With extended loader (passing empty string)
--- | ---
![issue](https://github.com/Fieldwire/filament/assets/17508872/93c57db7-0d7f-4fe8-b00e-2689eaf86bb8)|![fix](https://github.com/Fieldwire/filament/assets/17508872/0ad35d61-cd7a-4ed3-bdc3-c23c6f9b766a)
