### PR TITLE
Revert "Include extended asset loader android"

### DIFF
--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -125,9 +125,7 @@ class ModelViewer(
         view.camera = camera
 
         materialProvider = UbershaderProvider(engine)
-        // Just pass in an empty string, see https://github.com/google/filament/issues/7905#issuecomment-2161779784,
-        // to opt for the extended asset loader until https://github.com/google/filament/issues/7782 is done
-        assetLoader = AssetLoader(engine, materialProvider, EntityManager.get(), "")
+        assetLoader = AssetLoader(engine, materialProvider, EntityManager.get())
         resourceLoader = ResourceLoader(engine, normalizeSkinningWeights)
 
         // Always add a direct light source since it is required for shadowing.

--- a/android/gltfio-android/src/main/cpp/AssetLoader.cpp
+++ b/android/gltfio-android/src/main/cpp/AssetLoader.cpp
@@ -263,48 +263,6 @@ Java_com_google_android_filament_gltfio_AssetLoader_nCreateAsset(JNIEnv* env, jc
             buffer.getSize());
 }
 
-
-extern "C" JNIEXPORT jlong JNICALL
-Java_com_google_android_filament_gltfio_AssetLoader_nCreateAssetLoaderExtended(JNIEnv* env, jclass,
-                                                                               jlong nativeEngine, jobject provider, jlong nativeEntities, jstring filePath) {
-    Engine* engine = (Engine*) nativeEngine;
-    MaterialProvider* materialProvider = nullptr;
-
-    // First check for a fast path that passes a native MaterialProvider into the loader.
-    // This drastically reduces the number of JNI calls while the asset is being loaded.
-    jclass klass = env->GetObjectClass(provider);
-    jmethodID getNativeObject = env->GetMethodID(klass, "getNativeObject", "()J");
-    if (getNativeObject) {
-        materialProvider = (MaterialProvider*) env->CallLongMethod(provider, getNativeObject);
-    } else {
-        env->ExceptionClear();
-    }
-
-    if (materialProvider == nullptr) {
-        materialProvider = new JavaMaterialProvider(env, provider);
-    }
-
-    EntityManager* entities = (EntityManager*) nativeEntities;
-    NameComponentManager* names = new NameComponentManager(*entities);
-
-    const char *nativeFilePath = env->GetStringUTFChars(filePath, nullptr);
-
-    AssetConfigurationExtended ext = {
-            .gltfPath = nativeFilePath
-    };
-
-    AssetConfiguration config = {
-            .engine = engine,
-            .materials = materialProvider,
-            .names = names,
-            .ext = &ext,
-    };
-
-    env->ReleaseStringUTFChars(filePath, nativeFilePath);
-
-    return (jlong) AssetLoader::create(config);
-}
-
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_gltfio_AssetLoader_nCreateInstancedAsset(JNIEnv* env, jclass,
         jlong nativeLoader, jobject javaBuffer, jint remaining, jlongArray instances) {

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
@@ -103,25 +103,6 @@ public class AssetLoader {
         mMaterialCache = provider;
     }
 
-    public AssetLoader(@NonNull Engine engine, @NonNull MaterialProvider provider,
-                       @NonNull EntityManager entities, String filePath) {
-
-        long nativeEngine = engine.getNativeObject();
-        long nativeEntities = entities.getNativeObject();
-        if (filePath == null) {
-            mNativeObject = nCreateAssetLoader(nativeEngine, provider, nativeEntities);
-        } else {
-            mNativeObject = nCreateAssetLoaderExtended(nativeEngine, provider, nativeEntities, filePath);
-        }
-
-        if (mNativeObject == 0) {
-            throw new IllegalStateException("Unable to parse glTF asset.");
-        }
-
-        mEngine = engine;
-        mMaterialCache = provider;
-    }
-
     /**
      * Frees all memory consumed by the native <code>AssetLoader</code>
      *
@@ -209,8 +190,6 @@ public class AssetLoader {
 
     private static native long nCreateAssetLoader(long nativeEngine, Object provider,
             long nativeEntities);
-    private static native long nCreateAssetLoaderExtended(long nativeEngine, Object provider,
-                                                          long nativeEntities, String filePath);
     private static native void nDestroyAssetLoader(long nativeLoader);
     private static native long nCreateAsset(long nativeLoader, Buffer buffer, int remaining);
     private static native long nCreateInstancedAsset(long nativeLoader, Buffer buffer, int remaining,

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -1588,10 +1588,8 @@ void FAssetLoader::importSkins(FFilamentInstance* instance, const cgltf_data* gl
     }
 }
 
-// Including support for Android
-// See https://github.com/google/filament/discussions/7851#discussioncomment-9453369
 bool AssetConfigurationExtended::isSupported() {
-#if defined(IOS) || defined(__EMSCRIPTEN__)
+#if defined(__ANDROID__) || defined(IOS) || defined(__EMSCRIPTEN__)
     return false;
 #else
     return true;


### PR DESCRIPTION
Reverts Fieldwire/filament#6

Opting in to extended asset loader degrades the performance drastically.  Created an issue, https://github.com/google/filament/issues/7930

We'll have to export the normals during conversion as a work around for the incorrect model appearance issue.  More info on [this](https://github.com/google/filament/discussions/7851) discussion

If Filament provides a fix, we'll create a new PR with these changes.  We could also make it optional from Java world but since the API for the fix is more of a patch & there's an [issue](https://github.com/google/filament/issues/7782) to create a standard API, am just reverting the changes