### PR TITLE
Adding parent name as default if node has no name

### DIFF
--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -573,7 +573,11 @@ void FAssetLoader::recurseEntities(const cgltf_node* node, SceneMask scenes, Ent
     instance->mEntities.push_back(entity);
     instance->mNodeMap[node - srcAsset->nodes] = entity;
 
-    const char* name = getNodeName(node, mDefaultNodeName);
+    const char* parentName = nullptr;
+    if (mNameManager->hasComponent(parent)) {
+        parentName = mNameManager->getName(mNameManager->getInstance(parent));
+    }
+    const char* name = getNodeName(node, parentName ? parentName : mDefaultNodeName);
 
     if (name) {
         fAsset->mNameToEntity[name].push_back(entity);


### PR DESCRIPTION
In the below `gltf` the node [3] acts as a parent, with no geometry of its own, with three children.  None of those three children have a name so we couldn't identify those entities.  So adding parent name as a name for the child if it doesn't have the name of its own.  

Improvement:
Other way to fix would be to find the parent name at runtime when an entity is clicked by adding a reference to parent entity, currently Entity doesn't have a reference to its parent.  That would speed up the `createInstance` since it wouldn't find the parent.  


Before | After
--- | ---
<video src="https://github.com/user-attachments/assets/a9d69238-7f23-4f1f-af53-bdde3f301b83">|<video src="https://github.com/user-attachments/assets/357db81a-6c6d-4b91-934f-d6884855079e">



