### PR TITLE
Adding a parameter in Java for defaultNodeName.

### DIFF
--- a/android/filamat-android/build.gradle
+++ b/android/filamat-android/build.gradle
@@ -7,6 +7,14 @@ android {
             withJavadocJar()
         }
     }
+
+    buildTypes {
+        debug {
+            packaging {
+                jniLibs.keepDebugSymbols += "**/*.so"
+            }
+        }
+    }
 }
 
 dependencies {

--- a/android/filament-android/build.gradle
+++ b/android/filament-android/build.gradle
@@ -7,6 +7,14 @@ android {
             withJavadocJar()
         }
     }
+
+    buildTypes {
+        debug {
+            packaging {
+                jniLibs.keepDebugSymbols += "**/*.so"
+            }
+        }
+    }
 }
 
 dependencies {

--- a/android/filament-utils-android/build.gradle
+++ b/android/filament-utils-android/build.gradle
@@ -22,6 +22,14 @@ android {
         }
     }
 
+    buildTypes {
+        debug {
+            packaging {
+                jniLibs.keepDebugSymbols += "**/*.so"
+            }
+        }
+    }
+
     publishing {
         singleVariant("release") {
             withSourcesJar()

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -125,7 +125,7 @@ class ModelViewer(
         view.camera = camera
 
         materialProvider = UbershaderProvider(engine)
-        assetLoader = AssetLoader(engine, materialProvider, EntityManager.get())
+        assetLoader = AssetLoader(engine, materialProvider, EntityManager.get(), "", "UndefinedObjectName")
         resourceLoader = ResourceLoader(engine, normalizeSkinningWeights)
 
         // Always add a direct light source since it is required for shadowing.

--- a/android/gltfio-android/build.gradle
+++ b/android/gltfio-android/build.gradle
@@ -11,6 +11,14 @@ android {
         }
     }
 
+    buildTypes {
+        debug {
+            packaging {
+                jniLibs.keepDebugSymbols += "**/*.so"
+            }
+        }
+    }
+
     publishing {
         singleVariant("release") {
             withSourcesJar()

--- a/android/gltfio-android/src/main/cpp/AssetLoader.cpp
+++ b/android/gltfio-android/src/main/cpp/AssetLoader.cpp
@@ -222,7 +222,7 @@ public:
 
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_gltfio_AssetLoader_nCreateAssetLoader(JNIEnv* env, jclass,
-        jlong nativeEngine, jobject provider, jlong nativeEntities) {
+        jlong nativeEngine, jobject provider, jlong nativeEntities, jstring defaultNodeName) {
     Engine* engine = (Engine*) nativeEngine;
     MaterialProvider* materialProvider = nullptr;
 
@@ -240,9 +240,14 @@ Java_com_google_android_filament_gltfio_AssetLoader_nCreateAssetLoader(JNIEnv* e
         materialProvider = new JavaMaterialProvider(env, provider);
     }
 
+    const char *nativeDefaultNodeName = env->GetStringUTFChars(defaultNodeName, nullptr);
+
+    env->ReleaseStringUTFChars(defaultNodeName,  nativeDefaultNodeName);
+
     EntityManager* entities = (EntityManager*) nativeEntities;
     NameComponentManager* names = new NameComponentManager(*entities);
-    return (jlong) AssetLoader::create({engine, materialProvider, names, entities});
+    return (jlong) AssetLoader::create({engine, materialProvider, names, entities,
+                                        const_cast<char *>(nativeDefaultNodeName)});
 }
 
 extern "C" JNIEXPORT void JNICALL
@@ -266,7 +271,7 @@ Java_com_google_android_filament_gltfio_AssetLoader_nCreateAsset(JNIEnv* env, jc
 
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_gltfio_AssetLoader_nCreateAssetLoaderExtended(JNIEnv* env, jclass,
-                                                                               jlong nativeEngine, jobject provider, jlong nativeEntities, jstring filePath) {
+                                                                               jlong nativeEngine, jobject provider, jlong nativeEntities, jstring filePath, jstring defaultNodeName) {
     Engine* engine = (Engine*) nativeEngine;
     MaterialProvider* materialProvider = nullptr;
 
@@ -288,6 +293,7 @@ Java_com_google_android_filament_gltfio_AssetLoader_nCreateAssetLoaderExtended(J
     NameComponentManager* names = new NameComponentManager(*entities);
 
     const char *nativeFilePath = env->GetStringUTFChars(filePath, nullptr);
+    const char *nativeDefaultNodeName = env->GetStringUTFChars(defaultNodeName, nullptr);
 
     AssetConfigurationExtended ext = {
             .gltfPath = nativeFilePath
@@ -297,10 +303,12 @@ Java_com_google_android_filament_gltfio_AssetLoader_nCreateAssetLoaderExtended(J
             .engine = engine,
             .materials = materialProvider,
             .names = names,
+            .defaultNodeName = const_cast<char *>(nativeDefaultNodeName),
             .ext = &ext,
     };
 
     env->ReleaseStringUTFChars(filePath, nativeFilePath);
+    env->ReleaseStringUTFChars(defaultNodeName,  nativeDefaultNodeName);
 
     return (jlong) AssetLoader::create(config);
 }

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
@@ -89,11 +89,11 @@ public class AssetLoader {
      * @param entities the EntityManager that should be used to create entities
      */
     public AssetLoader(@NonNull Engine engine, @NonNull MaterialProvider provider,
-            @NonNull EntityManager entities) {
+            @NonNull EntityManager entities, String defaultNodeName) {
 
         long nativeEngine = engine.getNativeObject();
         long nativeEntities = entities.getNativeObject();
-        mNativeObject = nCreateAssetLoader(nativeEngine, provider, nativeEntities);
+        mNativeObject = nCreateAssetLoader(nativeEngine, provider, nativeEntities, defaultNodeName);
 
         if (mNativeObject == 0) {
             throw new IllegalStateException("Unable to parse glTF asset.");
@@ -104,14 +104,14 @@ public class AssetLoader {
     }
 
     public AssetLoader(@NonNull Engine engine, @NonNull MaterialProvider provider,
-                       @NonNull EntityManager entities, String filePath) {
+                       @NonNull EntityManager entities, String filePath, String defaultNodeName) {
 
         long nativeEngine = engine.getNativeObject();
         long nativeEntities = entities.getNativeObject();
         if (filePath == null) {
-            mNativeObject = nCreateAssetLoader(nativeEngine, provider, nativeEntities);
+            mNativeObject = nCreateAssetLoader(nativeEngine, provider, nativeEntities, defaultNodeName);
         } else {
-            mNativeObject = nCreateAssetLoaderExtended(nativeEngine, provider, nativeEntities, filePath);
+            mNativeObject = nCreateAssetLoaderExtended(nativeEngine, provider, nativeEntities, filePath, defaultNodeName);
         }
 
         if (mNativeObject == 0) {
@@ -208,9 +208,9 @@ public class AssetLoader {
     }
 
     private static native long nCreateAssetLoader(long nativeEngine, Object provider,
-            long nativeEntities);
+            long nativeEntities, String defaultNodeName);
     private static native long nCreateAssetLoaderExtended(long nativeEngine, Object provider,
-                                                          long nativeEntities, String filePath);
+                                                          long nativeEntities, String filePath, String defaultNodeName);
     private static native void nDestroyAssetLoader(long nativeLoader);
     private static native long nCreateAsset(long nativeLoader, Buffer buffer, int remaining);
     private static native long nCreateInstancedAsset(long nativeLoader, Buffer buffer, int remaining,

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -96,6 +96,11 @@ static std::string getNodeName(cgltf_node const* node, char const* defaultNodeNa
         if (node->mesh && node->mesh->name) return node->mesh->name;
         if (node->light && node->light->name) return node->light->name;
         if (node->camera && node->camera->name) return node->camera->name;
+        // Some GLTF models have nodes that do not have geometry but act as a parent for other nodes
+        // Those child nodes do not have a name but inherit the parent's name. Since Entity do not store
+        // reference to its parent, there is no way to get the name of the parent when one of those
+        // child entity is selected. So falling back to parent node name if this node doesn't have one
+        if (node->parent && node->parent->name) return node->parent->name;
         return defaultNodeName;
     };
 
@@ -621,15 +626,7 @@ void FAssetLoader::recurseEntities(const cgltf_node* node, SceneMask scenes, Ent
     instance->mEntities.push_back(entity);
     instance->mNodeMap[node - srcAsset->nodes] = entity;
 
-    // Some GLTF models have nodes that do not have geometry but act as a parent for other nodes
-    // Those child nodes do not have a name but inherit the parent's name. Since Entity do not store
-    // reference to its parent, there is no way to get the name of the parent when one of those
-    // child entity is selected. So falling back to parent entity name if this entity don't have one
-    const char* parentName = nullptr;
-    if (mNameManager->hasComponent(parent)) {
-        parentName = mNameManager->getName(mNameManager->getInstance(parent));
-    }
-    auto nameStr = getNodeName(node, parentName ? parentName : mDefaultNodeName);
+    auto nameStr = getNodeName(node, mDefaultNodeName);
     const char* name = nameStr.c_str();
 
     if (name) {


### PR DESCRIPTION
Filament crashes in debug mode when loading a model containing nodes without name field.  So added a defaultNodeName parameter in Java