### PR TITLE
ME-6451 register mesh information

### DIFF
--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -16,6 +16,7 @@ set(PUBLIC_HDRS
         include/gltfio/FilamentInstance.h
         include/gltfio/MaterialProvider.h
         include/gltfio/NodeManager.h
+        include/gltfio/PickingRegistry.h
         include/gltfio/TrsTransformManager.h
         include/gltfio/ResourceLoader.h
         include/gltfio/TextureProvider.h
@@ -41,6 +42,7 @@ set(SRCS
         src/Ktx2Provider.cpp
         src/MaterialProvider.cpp
         src/NodeManager.cpp
+        src/PickingRegistry.cpp
         src/TrsTransformManager.cpp
         src/ResourceLoader.cpp
         src/StbProvider.cpp

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -21,6 +21,7 @@
 #include <filament/TextureSampler.h>
 
 #include <gltfio/NodeManager.h>
+#include <gltfio/PickingRegistry.h>
 
 #include <utils/compiler.h>
 #include <utils/Entity.h>
@@ -293,6 +294,9 @@ public:
     FilamentInstance* getInstance() noexcept {
         return getAssetInstanceCount() > 0 ? getAssetInstances()[0] : nullptr;
     }
+
+    /** Access the picking registry (may be empty if no meshes registered yet). */
+    PickingRegistry* getPickingRegistry() noexcept;
 
     /*! \cond PRIVATE */
 

--- a/libs/gltfio/include/gltfio/PickingRegistry.h
+++ b/libs/gltfio/include/gltfio/PickingRegistry.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLTFIO_PICKING_REGISTRY_H
+#define GLTFIO_PICKING_REGISTRY_H
+
+#include <utils/Entity.h>
+#include <math/vec3.h>
+
+#include <vector>
+#include <unordered_map>
+#include <memory>
+
+// Forward declaration of cgltf types
+struct cgltf_mesh;
+
+// Forward declaration of tinybvh BVH
+namespace tinybvh {
+    class BVH;
+}
+
+namespace filament::gltfio {
+
+/**
+ * MeshData stores the geometry data and BVH for fast ray-triangle intersection.
+ */
+struct MeshData {
+    std::vector<math::float3> positions;       // Vertex positions in local space
+    std::vector<uint32_t> indices;             // Triangle indices (3 per triangle)
+    std::unique_ptr<tinybvh::BVH> bvh;         // BVH for accelerated ray tracing
+
+    MeshData() = default;
+    MeshData(MeshData&&) noexcept = default;
+    MeshData& operator=(MeshData&&) noexcept = default;
+
+    // Disable copy to avoid expensive copies
+    MeshData(const MeshData&) = delete;
+    MeshData& operator=(const MeshData&) = delete;
+};
+
+/**
+ * PickingRegistry manages mesh data for entities and builds BVH acceleration structures.
+ *
+ * This class stores geometry data and BVH for each entity, enabling fast spatial queries.
+ */
+class PickingRegistry {
+public:
+    PickingRegistry();
+    ~PickingRegistry();
+
+    // Disable copy operations
+    PickingRegistry(const PickingRegistry&) = delete;
+    PickingRegistry& operator=(const PickingRegistry&) = delete;
+
+    // Enable move operations (implemented in .cpp where MeshData is complete)
+    PickingRegistry(PickingRegistry&&) noexcept;
+    PickingRegistry& operator=(PickingRegistry&&) noexcept;
+
+    /**
+     * Register a mesh from a GLTF mesh structure.
+     * Extracts geometry data from the GLTF mesh and builds the BVH.
+     *
+     * @param entity The entity to associate with this mesh
+     * @param mesh The GLTF mesh to extract geometry from
+     * @return true if registration was successful, false otherwise
+     */
+    bool registerMesh(utils::Entity entity, const cgltf_mesh* mesh);
+
+    /**
+     * Unregister a mesh associated with an entity.
+     *
+     * @param entity The entity whose mesh data should be removed
+     */
+    void unregisterMesh(utils::Entity entity);
+
+    /**
+     * Get the mesh data for a specific entity.
+     *
+     * @param entity The entity to query
+     * @return Pointer to MeshData or nullptr if entity not registered
+     */
+    const MeshData* getMeshData(utils::Entity entity) const;
+
+    /**
+     * Check if an entity has registered mesh data.
+     *
+     * @param entity The entity to check
+     * @return true if entity has mesh data, false otherwise
+     */
+    bool hasMesh(utils::Entity entity) const;
+
+    /**
+     * Get the number of registered meshes.
+     *
+     * @return Number of registered entities
+     */
+    size_t getMeshCount() const;
+
+    /**
+     * Clear all registered meshes.
+     */
+    void clear();
+
+private:
+    // Build BVH for a mesh
+    void buildBVH(MeshData& meshData);
+
+    // Entity to mesh data mapping
+    std::unordered_map<utils::Entity, MeshData, utils::Entity::Hasher> mMeshes;
+};
+
+} // namespace filament::gltfio
+
+#endif // GLTFIO_PICKING_REGISTRY_H
+
+

--- a/libs/gltfio/include/gltfio/PickingRegistry.h
+++ b/libs/gltfio/include/gltfio/PickingRegistry.h
@@ -30,6 +30,7 @@ struct cgltf_mesh;
 // Forward declaration of tinybvh BVH
 namespace tinybvh {
     class BVH;
+    struct bvhvec4;
 }
 
 namespace filament::gltfio {
@@ -41,6 +42,7 @@ struct MeshData {
     std::vector<math::float3> positions;       // Vertex positions in local space
     std::vector<uint32_t> indices;             // Triangle indices (3 per triangle)
     std::unique_ptr<tinybvh::BVH> bvh;         // BVH for accelerated ray tracing
+    std::vector<tinybvh::bvhvec4> bvhTriangles; // Triangle data in TinyBVH format (3 bvhvec4 per triangle)
 
     MeshData() = default;
     MeshData(MeshData&&) noexcept = default;
@@ -78,36 +80,6 @@ public:
      * @return true if registration was successful, false otherwise
      */
     bool registerMesh(utils::Entity entity, const cgltf_mesh* mesh);
-
-    /**
-     * Unregister a mesh associated with an entity.
-     *
-     * @param entity The entity whose mesh data should be removed
-     */
-    void unregisterMesh(utils::Entity entity);
-
-    /**
-     * Get the mesh data for a specific entity.
-     *
-     * @param entity The entity to query
-     * @return Pointer to MeshData or nullptr if entity not registered
-     */
-    const MeshData* getMeshData(utils::Entity entity) const;
-
-    /**
-     * Check if an entity has registered mesh data.
-     *
-     * @param entity The entity to check
-     * @return true if entity has mesh data, false otherwise
-     */
-    bool hasMesh(utils::Entity entity) const;
-
-    /**
-     * Get the number of registered meshes.
-     *
-     * @return Number of registered entities
-     */
-    size_t getMeshCount() const;
 
     /**
      * Clear all registered meshes.

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -908,6 +908,10 @@ void FAssetLoader::createRenderable(const cgltf_node* node, Entity entity, const
         }
         mRenderableManager.setMorphWeights(renderable, weights.data(), size);
     }
+
+    // After successfully creating the renderable with RenderableManager::Builder
+    // and the mesh has been assigned, register it for picking
+    fAsset->mPickingRegistry.registerMesh(entity, node->mesh);
 }
 
 void FAssetLoader::createMaterialVariants(const cgltf_mesh* mesh, Entity entity,

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -909,9 +909,12 @@ void FAssetLoader::createRenderable(const cgltf_node* node, Entity entity, const
         mRenderableManager.setMorphWeights(renderable, weights.data(), size);
     }
 
-    // After successfully creating the renderable with RenderableManager::Builder
-    // and the mesh has been assigned, register it for picking
-    fAsset->mPickingRegistry.registerMesh(entity, node->mesh);
+    // Defer mesh registration for picking until ResourceLoader has loaded cgltf buffers
+    // At this point, buffer->data is NULL, so we can't read vertex positions yet
+    // Store the entity-mesh pair to be processed later in ResourceLoader::loadResources()
+    if (node->mesh) {
+        fAsset->mPendingMeshRegistrations.emplace_back(entity, node->mesh);
+    }
 }
 
 void FAssetLoader::createMaterialVariants(const cgltf_mesh* mesh, Entity entity,

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -230,6 +230,10 @@ struct FFilamentAsset : public FilamentAsset {
     void addEntitiesToScene(Scene& targetScene, const Entity* entities, size_t count,
             SceneMask sceneFilter) const;
 
+    PickingRegistry* getPickingRegistry() noexcept {
+        return &mPickingRegistry;
+    }
+
     void detachFilamentComponents() noexcept {
         mDetachedFilamentComponents = true;
     }
@@ -324,6 +328,9 @@ struct FFilamentAsset : public FilamentAsset {
     // The mapping from cgltf_mesh to VertexBuffer* (etc) is required when creating new instances.
     MeshCache mMeshCache;
 
+    // Pending mesh registrations for picking - processed after buffers are loaded
+    std::vector<std::pair<utils::Entity, const cgltf_mesh*>> mPendingMeshRegistrations;
+
     // Asset information that is produced by AssetLoader and consumed by ResourceLoader:
     struct ResourceInfo {
         // Encapsulates VertexBuffer::setBufferAt() or IndexBuffer::setBuffer().
@@ -374,6 +381,10 @@ struct FFilamentAsset : public FilamentAsset {
 
     std::variant<ResourceInfo, ResourceInfoExtended> mResourceInfo;
 
+    /**
+     * Picking registry for triangle-level ray intersection testing.
+     * Automatically populated during asset loading.
+     */
     PickingRegistry mPickingRegistry;
 };
 

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -46,6 +46,7 @@
 #include "DracoCache.h"
 #include "FFilamentInstance.h"
 #include "Utility.h"
+#include "gltfio/PickingRegistry.h"
 
 #include <string>
 #include <unordered_map>
@@ -372,6 +373,8 @@ struct FFilamentAsset : public FilamentAsset {
     };
 
     std::variant<ResourceInfo, ResourceInfoExtended> mResourceInfo;
+
+    PickingRegistry mPickingRegistry;
 };
 
 FILAMENT_DOWNCAST(FilamentAsset)

--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -47,6 +47,9 @@ FFilamentAsset::~FFilamentAsset() {
 
     delete mWireframe;
 
+    // Start fresh
+    mPickingRegistry.clear();
+
     // Destroy name components.
     if (mNameManager) {
         for (auto entity : mEntities) {
@@ -437,6 +440,10 @@ const char* FilamentAsset::getSceneName(size_t sceneIndex) const noexcept {
 void FilamentAsset::addEntitiesToScene(Scene& targetScene, const Entity* entities, size_t count,
         SceneMask sceneFilter) const {
     downcast(this)->addEntitiesToScene(targetScene, entities, count, sceneFilter);
+}
+
+PickingRegistry* FilamentAsset::getPickingRegistry() noexcept {
+    return downcast(this)->getPickingRegistry();
 }
 
 } // namespace filament::gltfio

--- a/libs/gltfio/src/PickingRegistry.cpp
+++ b/libs/gltfio/src/PickingRegistry.cpp
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gltfio/PickingRegistry.h>
+
+// TinyBVH - Fast BVH-based ray tracing
+// Source: https://github.com/jbikker/tinybvh (commit 4b5b649)
+#define TINYBVH_IMPLEMENTATION
+#include "../../third_party/tiny-bvh/tiny_bvh.h"
+
+#include <cgltf.h>
+#include <utils/Log.h>
+
+#include <algorithm>
+
+using namespace filament::math;
+using namespace utils;
+
+namespace filament::gltfio {
+
+// ============================================================================
+// Constructor / Destructor
+// ============================================================================
+
+PickingRegistry::PickingRegistry() = default;
+
+// Destructor must be defined in .cpp where MeshData is complete
+// This allows std::unique_ptr<tinybvh::BVH> to properly destroy
+PickingRegistry::~PickingRegistry() = default;
+
+// Move operations must be defined where MeshData is complete
+PickingRegistry::PickingRegistry(PickingRegistry&&) noexcept = default;
+PickingRegistry& PickingRegistry::operator=(PickingRegistry&&) noexcept = default;
+
+// ============================================================================
+// Mesh Registration
+// ============================================================================
+
+bool PickingRegistry::registerMesh(const Entity entity, const cgltf_mesh* mesh) {
+    if (!mesh) {
+        slog.w << "PickingRegistry: NULL mesh pointer for entity " << entity.getId() << io::endl;
+        return false;
+    }
+
+    std::vector<float3> positions;
+    std::vector<uint32_t> indices;
+
+    // Iterate through all primitives in the mesh
+    for (size_t primIdx = 0; primIdx < mesh->primitives_count; ++primIdx) {
+        const cgltf_primitive& primitive = mesh->primitives[primIdx];
+
+        // Only handle triangle primitives
+        if (primitive.type != cgltf_primitive_type_triangles) {
+            continue;
+        }
+
+        // Extract vertex positions
+        const cgltf_accessor* posAccessor = nullptr;
+        for (size_t attrIdx = 0; attrIdx < primitive.attributes_count; ++attrIdx) {
+            if (primitive.attributes[attrIdx].type == cgltf_attribute_type_position) {
+                posAccessor = primitive.attributes[attrIdx].data;
+                break;
+            }
+        }
+
+        if (!posAccessor) {
+            slog.w << "PickingRegistry: No position attribute in primitive " << primIdx << io::endl;
+            continue;
+        }
+
+        // Read vertex positions
+        size_t vertexOffset = positions.size();
+        size_t vertexCount = posAccessor->count;
+        positions.resize(vertexOffset + vertexCount);
+
+        for (size_t i = 0; i < vertexCount; ++i) {
+            float pos[3];
+            cgltf_accessor_read_float(posAccessor, i, pos, 3);
+            positions[vertexOffset + i] = float3(pos[0], pos[1], pos[2]);
+        }
+
+        // Extract indices
+        const cgltf_accessor* indexAccessor = primitive.indices;
+        if (indexAccessor) {
+            size_t indexCount = indexAccessor->count;
+            size_t indexOffset = indices.size();
+            indices.resize(indexOffset + indexCount);
+
+            for (size_t i = 0; i < indexCount; ++i) {
+                indices[indexOffset + i] = static_cast<uint32_t>(
+                    cgltf_accessor_read_index(indexAccessor, i) + vertexOffset
+                );
+            }
+        } else {
+            // No indices - vertices define triangles directly (v0, v1, v2), (v3, v4, v5), ...
+            slog.w << "PickingRegistry: Mesh primitive has no index buffer, generating sequential indices (entity "
+                   << entity.getId() << ")" << io::endl;
+
+            size_t indexOffset = indices.size();
+            indices.resize(indexOffset + vertexCount);
+            for (size_t i = 0; i < vertexCount; ++i) {
+                indices[indexOffset + i] = static_cast<uint32_t>(vertexOffset + i);
+            }
+        }
+    }
+
+    if (positions.empty() || indices.empty()) {
+        slog.w << "PickingRegistry: No valid geometry extracted from mesh" << io::endl;
+        return false;
+    }
+
+    // Create mesh data and build BVH
+    MeshData meshData;
+    meshData.positions = std::move(positions);
+    meshData.indices = std::move(indices);
+
+    // Validate mesh data
+    if (meshData.indices.size() % 3 != 0) {
+        slog.w << "PickingRegistry: Invalid index count " << meshData.indices.size()
+               << " for entity " << entity.getId() << " (must be multiple of 3)" << io::endl;
+        return false;
+    }
+
+    // Build BVH for fast ray intersection
+    buildBVH(meshData);
+
+    // Store in registry
+    mMeshes[entity] = std::move(meshData);
+
+    slog.d << "PickingRegistry: Registered mesh for entity " << entity.getId()
+           << " with " << (meshData.indices.size() / 3) << " triangles" << io::endl;
+
+    return true;
+}
+
+void PickingRegistry::unregisterMesh(utils::Entity entity) {
+    auto it = mMeshes.find(entity);
+    if (it != mMeshes.end()) {
+        mMeshes.erase(it);
+        slog.d << "PickingRegistry: Unregistered mesh for entity " << entity.getId() << io::endl;
+    }
+}
+
+// ============================================================================
+// BVH Construction
+// ============================================================================
+
+void PickingRegistry::buildBVH(MeshData& meshData) {
+    const size_t triangleCount = meshData.indices.size() / 3;
+
+    if (triangleCount == 0) {
+        slog.w << "PickingRegistry: Cannot build BVH for mesh with 0 triangles" << io::endl;
+        return;
+    }
+
+    // Create BVH instance
+    meshData.bvh = std::make_unique<tinybvh::BVH>();
+
+    // Convert triangle data to tinybvh format (vec4 per vertex, 3 vertices per triangle)
+    std::vector<tinybvh::bvhvec4> bvhTriangles;
+    bvhTriangles.reserve(triangleCount * 3);
+
+    for (size_t i = 0; i < triangleCount; ++i) {
+        uint32_t idx0 = meshData.indices[i * 3 + 0];
+        uint32_t idx1 = meshData.indices[i * 3 + 1];
+        uint32_t idx2 = meshData.indices[i * 3 + 2];
+
+        const float3& v0 = meshData.positions[idx0];
+        const float3& v1 = meshData.positions[idx1];
+        const float3& v2 = meshData.positions[idx2];
+
+        bvhTriangles.push_back(tinybvh::bvhvec4(v0.x, v0.y, v0.z, 0.0f));
+        bvhTriangles.push_back(tinybvh::bvhvec4(v1.x, v1.y, v1.z, 0.0f));
+        bvhTriangles.push_back(tinybvh::bvhvec4(v2.x, v2.y, v2.z, 0.0f));
+    }
+
+    // Build the BVH - TinyBVH handles all AABB computation and tree construction
+    meshData.bvh->Build(bvhTriangles.data(), static_cast<unsigned int>(triangleCount));
+
+    slog.d << "PickingRegistry: Built BVH for " << triangleCount << " triangles" << io::endl;
+}
+
+// ============================================================================
+// Query Methods
+// ============================================================================
+
+const MeshData* PickingRegistry::getMeshData(utils::Entity entity) const {
+    auto it = mMeshes.find(entity);
+    return it != mMeshes.end() ? &it->second : nullptr;
+}
+
+bool PickingRegistry::hasMesh(utils::Entity entity) const {
+    return mMeshes.find(entity) != mMeshes.end();
+}
+
+size_t PickingRegistry::getMeshCount() const {
+    return mMeshes.size();
+}
+
+void PickingRegistry::clear() {
+    mMeshes.clear();
+    slog.d << "PickingRegistry: Cleared all meshes" << io::endl;
+}
+} // namespace filament::gltfio

--- a/libs/gltfio/src/PickingRegistry.cpp
+++ b/libs/gltfio/src/PickingRegistry.cpp
@@ -105,10 +105,6 @@ bool PickingRegistry::registerMesh(const Entity entity, const cgltf_mesh* mesh) 
                 );
             }
         } else {
-            // No indices - vertices define triangles directly (v0, v1, v2), (v3, v4, v5), ...
-            slog.w << "PickingRegistry: Mesh primitive has no index buffer, generating sequential indices (entity "
-                   << entity.getId() << ")" << io::endl;
-
             size_t indexOffset = indices.size();
             indices.resize(indexOffset + vertexCount);
             for (size_t i = 0; i < vertexCount; ++i) {
@@ -140,18 +136,7 @@ bool PickingRegistry::registerMesh(const Entity entity, const cgltf_mesh* mesh) 
     // Store in registry
     mMeshes[entity] = std::move(meshData);
 
-    slog.d << "PickingRegistry: Registered mesh for entity " << entity.getId()
-           << " with " << (meshData.indices.size() / 3) << " triangles" << io::endl;
-
     return true;
-}
-
-void PickingRegistry::unregisterMesh(utils::Entity entity) {
-    auto it = mMeshes.find(entity);
-    if (it != mMeshes.end()) {
-        mMeshes.erase(it);
-        slog.d << "PickingRegistry: Unregistered mesh for entity " << entity.getId() << io::endl;
-    }
 }
 
 // ============================================================================
@@ -170,8 +155,9 @@ void PickingRegistry::buildBVH(MeshData& meshData) {
     meshData.bvh = std::make_unique<tinybvh::BVH>();
 
     // Convert triangle data to tinybvh format (vec4 per vertex, 3 vertices per triangle)
-    std::vector<tinybvh::bvhvec4> bvhTriangles;
-    bvhTriangles.reserve(triangleCount * 3);
+    // Store directly in meshData for persistence (TinyBVH stores a pointer to this data)
+    meshData.bvhTriangles.clear();
+    meshData.bvhTriangles.reserve(triangleCount * 3);
 
     for (size_t i = 0; i < triangleCount; ++i) {
         uint32_t idx0 = meshData.indices[i * 3 + 0];
@@ -182,32 +168,13 @@ void PickingRegistry::buildBVH(MeshData& meshData) {
         const float3& v1 = meshData.positions[idx1];
         const float3& v2 = meshData.positions[idx2];
 
-        bvhTriangles.push_back(tinybvh::bvhvec4(v0.x, v0.y, v0.z, 0.0f));
-        bvhTriangles.push_back(tinybvh::bvhvec4(v1.x, v1.y, v1.z, 0.0f));
-        bvhTriangles.push_back(tinybvh::bvhvec4(v2.x, v2.y, v2.z, 0.0f));
+        meshData.bvhTriangles.push_back(tinybvh::bvhvec4(v0.x, v0.y, v0.z, 0.0f));
+        meshData.bvhTriangles.push_back(tinybvh::bvhvec4(v1.x, v1.y, v1.z, 0.0f));
+        meshData.bvhTriangles.push_back(tinybvh::bvhvec4(v2.x, v2.y, v2.z, 0.0f));
     }
 
-    // Build the BVH - TinyBVH handles all AABB computation and tree construction
-    meshData.bvh->Build(bvhTriangles.data(), static_cast<unsigned int>(triangleCount));
-
-    slog.d << "PickingRegistry: Built BVH for " << triangleCount << " triangles" << io::endl;
-}
-
-// ============================================================================
-// Query Methods
-// ============================================================================
-
-const MeshData* PickingRegistry::getMeshData(utils::Entity entity) const {
-    auto it = mMeshes.find(entity);
-    return it != mMeshes.end() ? &it->second : nullptr;
-}
-
-bool PickingRegistry::hasMesh(utils::Entity entity) const {
-    return mMeshes.find(entity) != mMeshes.end();
-}
-
-size_t PickingRegistry::getMeshCount() const {
-    return mMeshes.size();
+    // Build the BVH - TinyBVH stores a pointer to this data, so it must persist!
+    meshData.bvh->Build(meshData.bvhTriangles.data(), static_cast<unsigned int>(triangleCount));
 }
 
 void PickingRegistry::clear() {

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -457,6 +457,15 @@ bool ResourceLoader::loadResources(FFilamentAsset* asset, bool async) {
         ResourceLoaderExtended::loadResources(slots, pImpl->mEngine, asset->mBufferObjects);
     }
 
+    // Register meshes for picking - this works for both standard and extended paths
+    // For standard path: buffers were just loaded above via loadCgltfBuffers()
+    // For extended path: buffers were loaded earlier in AssetLoaderExtended::createPrimitive()
+    // In both cases, buffer->data is now valid and we can read vertex positions
+    for (const auto& [entity, mesh] : asset->mPendingMeshRegistrations) {
+        asset->mPickingRegistry.registerMesh(entity, mesh);
+    }
+    asset->mPendingMeshRegistrations.clear();
+
     createSkins(gltf, pImpl->mNormalizeSkinningWeights, asset->mSkins);
 
     // If any decoding jobs are still underway from a previous load, wait for them to finish.


### PR DESCRIPTION
https://fieldwire.atlassian.net/browse/ME-6275

This PR sets up the base for triangle picking implementation.

Gets the vertex (triangle co-ordinates) and index data from source gltf.  AssetLoader parses the gltf file using cgltf library.  Once the parsing is done, we get reference to cgltf_mesh (mesh object in gltf) and read position & index data from it and store in PickingRegistry.

