### PR TITLE
Introduced swapIndexBuffer for triangle skipping

### DIFF
--- a/android/filament-android/src/main/cpp/RenderableManager.cpp
+++ b/android/filament-android/src/main/cpp/RenderableManager.cpp
@@ -515,3 +515,13 @@ Java_com_google_android_filament_RenderableManager_nGetLightChannel(JNIEnv*, jcl
     RenderableManager const *rm = (RenderableManager const *) nativeRenderableManager;
     return rm->getLightChannel((RenderableManager::Instance) i, channel);
 }
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_RenderableManager_nSwapIndexBufferAt(JNIEnv*, jclass,
+        jlong nativeRenderableManager, jint i, jint primitiveIndex, jlong nativeIndexBuffer,
+        jint offset, jint count) {
+    RenderableManager* rm = (RenderableManager*) nativeRenderableManager;
+    IndexBuffer* indexBuffer = (IndexBuffer*) nativeIndexBuffer;
+    rm->swapIndexBufferAt((RenderableManager::Instance) i, (size_t) primitiveIndex,
+            indexBuffer, (size_t) offset, (size_t) count);
+}

--- a/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
@@ -902,6 +902,13 @@ public class RenderableManager {
                 0, indices.getIndexCount());
     }
 
+    public void swapIndexBufferAt(@EntityInstance int i, @IntRange(from = 0) int primitiveIndex,
+            @NonNull IndexBuffer indices, @IntRange(from = 0) int offset,
+            @IntRange(from = 0) int count) {
+        nSwapIndexBufferAt(mNativeObject, i, primitiveIndex,
+                indices.getNativeObject(), offset, count);
+    }
+
      /**
      * Changes the drawing order for blended primitives. The drawing order is either global or
      * local (default) to this Renderable. In either case, the Renderable priority takes precedence.
@@ -1017,4 +1024,6 @@ public class RenderableManager {
     private static native void nSetBlendOrderAt(long nativeRenderableManager, int i, int primitiveIndex, int blendOrder);
     private static native void nSetGlobalBlendOrderEnabledAt(long nativeRenderableManager, int i, int primitiveIndex, boolean enabled);
     private static native int nGetEnabledAttributesAt(long nativeRenderableManager, int i, int primitiveIndex);
+    private static native void nSwapIndexBufferAt(long nativeRenderableManager, int i,
+            int primitiveIndex, long nativeIndexBuffer, int offset, int count);
 }

--- a/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
@@ -902,6 +902,22 @@ public class RenderableManager {
                 0, indices.getIndexCount());
     }
 
+    /**
+     * Swaps the {@link IndexBuffer} for the given primitive without touching the
+     * {@link VertexBuffer} or any other primitive state.
+     *
+     * <p>Use this to efficiently hide or filter triangles by supplying a pre-built index buffer
+     * that omits the unwanted indices, while reusing the existing vertex buffer as-is.</p>
+     *
+     * @param i              the renderable instance (from {@link #getInstance})
+     * @param primitiveIndex the primitive whose index buffer should be replaced
+     * @param indices        the new {@link IndexBuffer} to bind; must remain valid for the
+     *                       lifetime of this renderable or until the next swap/setGeometryAt call
+     * @param offset         offset into {@code indices}, in indices (not bytes)
+     * @param count          number of indices to draw starting at {@code offset}
+     *
+     * @see #setGeometryAt
+     */
     public void swapIndexBufferAt(@EntityInstance int i, @IntRange(from = 0) int primitiveIndex,
             @NonNull IndexBuffer indices, @IntRange(from = 0) int offset,
             @IntRange(from = 0) int count) {

--- a/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
+++ b/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
@@ -337,8 +337,10 @@ Java_com_google_android_filament_gltfio_FilamentAsset_nPick(JNIEnv* env, jclass,
 }
 
 /**
- * Returns mesh data info for an entity: [positionCount, indexCount, positionsPtr, indicesPtr]
+ * Returns mesh data buffer pointers and sizes for an entity.
+ * Returns a long array: [positionsPtr, positionsSize, indicesPtr, indicesSize, expandedIndicesPtr, expandedIndicesSize]
  * The pointers can be used to create direct ByteBuffers on the Java side.
+ * The sizes are in bytes (element count * element size).
  * This avoids copying data - the ByteBuffers will directly reference C++ memory.
  *
  * IMPORTANT: The returned pointers are only valid while the PickingRegistry exists.
@@ -364,99 +366,33 @@ Java_com_google_android_filament_gltfio_FilamentAsset_nGetMeshDataInfo(JNIEnv* e
 
     const MeshData& meshData = it->second;
 
-    // Return: [positionCount, indexCount, positionsPtr, indicesPtr]
-    jlongArray result = env->NewLongArray(4);
+    // Return: [positionsPtr, positionsSize, indicesPtr, indicesSize, expandedIndicesPtr, expandedIndicesSize]
+    jlongArray result = env->NewLongArray(6);
     if (result == nullptr) {
         return nullptr;
     }
 
-    jlong data[4];
-    data[0] = static_cast<jlong>(meshData.positions.size());
-    data[1] = static_cast<jlong>(meshData.indices.size());
-    data[2] = reinterpret_cast<jlong>(meshData.positions.data());
-    data[3] = reinterpret_cast<jlong>(meshData.indices.data());
+    jlong data[6];
+    data[0] = reinterpret_cast<jlong>(meshData.positions.data());
+    data[1] = static_cast<jlong>(meshData.positions.size() * sizeof(float3));
+    data[2] = reinterpret_cast<jlong>(meshData.indices.data());
+    data[3] = static_cast<jlong>(meshData.indices.size() * sizeof(uint32_t));
+    data[4] = reinterpret_cast<jlong>(meshData.expandedIndices.data());
+    data[5] = static_cast<jlong>(meshData.expandedIndices.size() * sizeof(uint32_t));
 
-    env->SetLongArrayRegion(result, 0, 4, data);
+    env->SetLongArrayRegion(result, 0, 6, data);
     return result;
 }
 
 /**
- * Creates a direct ByteBuffer wrapping the positions array for an entity.
- * The buffer directly references C++ memory - no copy is made.
- *
- * Each position is 3 floats (12 bytes). Total size = positionCount * 12 bytes.
- *
- * IMPORTANT: The buffer is only valid while the PickingRegistry/FilamentAsset exists.
+ * Helper method to create a direct ByteBuffer from a native pointer and capacity.
  */
 extern "C" JNIEXPORT jobject JNICALL
-Java_com_google_android_filament_gltfio_FilamentAsset_nGetMeshPositionsBuffer(JNIEnv* env, jclass,
-        jlong nativeAsset, jint entityId) {
-    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
-    PickingRegistry* registry = asset->getPickingRegistry();
-
-    if (!registry) {
+Java_com_google_android_filament_gltfio_FilamentAsset_nNewDirectByteBuffer(JNIEnv* env, jclass,
+        jlong address, jint capacity) {
+    if (address == 0 || capacity <= 0) {
         return nullptr;
     }
-
-    Entity entity = Entity::import(entityId);
-    const auto& meshes = registry->getMeshes();
-    auto it = meshes.find(entity);
-
-    if (it == meshes.end()) {
-        return nullptr;
-    }
-
-    const MeshData& meshData = it->second;
-
-    if (meshData.positions.empty()) {
-        return nullptr;
-    }
-
-    // Create a direct ByteBuffer that wraps the C++ memory
-    // Each float3 is 12 bytes (3 * sizeof(float))
-    jlong capacity = meshData.positions.size() * sizeof(float3);
-    void* address = const_cast<void*>(static_cast<const void*>(meshData.positions.data()));
-
-    return env->NewDirectByteBuffer(address, capacity);
-}
-
-/**
- * Creates a direct ByteBuffer wrapping the indices array for an entity.
- * The buffer directly references C++ memory - no copy is made.
- *
- * Each index is 4 bytes (uint32_t). Total size = indexCount * 4 bytes.
- *
- * IMPORTANT: The buffer is only valid while the PickingRegistry/FilamentAsset exists.
- */
-extern "C" JNIEXPORT jobject JNICALL
-Java_com_google_android_filament_gltfio_FilamentAsset_nGetMeshIndicesBuffer(JNIEnv* env, jclass,
-        jlong nativeAsset, jint entityId) {
-    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
-    PickingRegistry* registry = asset->getPickingRegistry();
-
-    if (!registry) {
-        return nullptr;
-    }
-
-    Entity entity = Entity::import(entityId);
-    const auto& meshes = registry->getMeshes();
-    auto it = meshes.find(entity);
-
-    if (it == meshes.end()) {
-        return nullptr;
-    }
-
-    const MeshData& meshData = it->second;
-
-    if (meshData.indices.empty()) {
-        return nullptr;
-    }
-
-    // Create a direct ByteBuffer that wraps the C++ memory
-    // Each uint32_t is 4 bytes
-    jlong capacity = meshData.indices.size() * sizeof(uint32_t);
-    void* address = const_cast<void*>(static_cast<const void*>(meshData.indices.data()));
-
-    return env->NewDirectByteBuffer(address, capacity);
+    return env->NewDirectByteBuffer(reinterpret_cast<void*>(address), capacity);
 }
 

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
@@ -378,31 +378,39 @@ public class FilamentAsset {
     }
 
     /**
-     * Gets mesh data (positions and indices) for an entity.
+     * Gets mesh data (positions, indices, and expanded indices) for an entity.
      *
-     * <p>The returned ByteBuffers directly reference native C++ memory, avoiding any copying.
-     * This is the most memory-efficient way to access mesh geometry data.</p>
+     * <p>The returned {@link MeshData} contains three direct {@link java.nio.ByteBuffer}s that
+     * reference native C++ memory owned by the {@code PickingRegistry} — no copy is made.</p>
      *
-     * <p><b>IMPORTANT:</b> The buffers are only valid while the FilamentAsset exists.
+     * <ul>
+     *   <li><b>positions</b> — float3 per vertex (x, y, z), 12 bytes each.
+     *       Vertex count = {@code positions.capacity() / 12}.</li>
+     *   <li><b>indices</b> — uint32 per index slot, 4 bytes each, 3 slots per triangle.
+     *       Triangle count = {@code indices.capacity() / 4 / 3}.</li>
+     *   <li><b>expandedIndices</b> — uint32, same layout as indices but remapped to the
+     *       expanded (de-duplicated) vertex buffer used by the GPU renderable. Present only
+     *       when the asset was loaded via {@code AssetLoaderExtended}; may be null otherwise.</li>
+     * </ul>
+     *
+     * <p><b>IMPORTANT:</b> The buffers are only valid while the {@link FilamentAsset} exists.
      * Do not cache or use them after the asset is destroyed.</p>
      *
      * <p>Example usage:</p>
      * <pre>
      * MeshData mesh = asset.getMeshData(entityId);
-     * if (mesh != null && mesh.positions != null) {
+     * if (mesh != null && mesh.positions != null && mesh.indices != null) {
      *     FloatBuffer positions = mesh.positions
      *         .order(ByteOrder.nativeOrder())
      *         .asFloatBuffer();
-     *     for (int i = 0; i < mesh.positionCount; i++) {
-     *         float x = positions.get(i * 3);
-     *         float y = positions.get(i * 3 + 1);
-     *         float z = positions.get(i * 3 + 2);
-     *     }
+     *     int vertexCount = mesh.positions.capacity() / 12; // 3 floats * 4 bytes
      *
      *     IntBuffer indices = mesh.indices
      *         .order(ByteOrder.nativeOrder())
      *         .asIntBuffer();
-     *     for (int i = 0; i < mesh.indexCount / 3; i++) {
+     *     int triangleCount = mesh.indices.capacity() / 4 / 3; // uint32, 3 per triangle
+     *
+     *     for (int i = 0; i < triangleCount; i++) {
      *         int i0 = indices.get(i * 3);
      *         int i1 = indices.get(i * 3 + 1);
      *         int i2 = indices.get(i * 3 + 2);
@@ -411,7 +419,9 @@ public class FilamentAsset {
      * </pre>
      *
      * @param entityId The entity to get mesh data for
-     * @return MeshData containing positions and indices, or null if not found
+     * @return {@link MeshData} containing positions, indices, and expandedIndices,
+     *         or null if the entity is not registered in the PickingRegistry or
+     *         any buffer size exceeds {@link Integer#MAX_VALUE}
      */
     @Nullable
     public MeshData getMeshData(@Entity int entityId) {

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
@@ -343,16 +343,10 @@ public class FilamentAsset {
      * </pre>
      */
     public static class MeshData {
-        /** Number of vertex positions (each position is 3 floats: x, y, z) */
-        public final int positionCount;
-
-        /** Number of indices (every 3 indices form a triangle) */
-        public final int indexCount;
-
         /**
          * Direct ByteBuffer containing positions as floats (x, y, z per vertex).
          * Read as FloatBuffer: positions.order(ByteOrder.nativeOrder()).asFloatBuffer()
-         * Total bytes = positionCount * 12 (3 floats * 4 bytes)
+         * Each position is 12 bytes (3 floats * 4 bytes)
          */
         @Nullable
         public final java.nio.ByteBuffer positions;
@@ -360,17 +354,26 @@ public class FilamentAsset {
         /**
          * Direct ByteBuffer containing indices as uint32.
          * Read as IntBuffer: indices.order(ByteOrder.nativeOrder()).asIntBuffer()
-         * Total bytes = indexCount * 4
+         * Each index is 4 bytes
          */
         @Nullable
         public final java.nio.ByteBuffer indices;
 
-        MeshData(int positionCount, int indexCount,
-                 java.nio.ByteBuffer positions, java.nio.ByteBuffer indices) {
-            this.positionCount = positionCount;
-            this.indexCount = indexCount;
+        /**
+         * Direct ByteBuffer containing expanded indices as uint32.
+         * Read as IntBuffer: expandedIndices.order(ByteOrder.nativeOrder()).asIntBuffer()
+         * Each index is 4 bytes
+         * This is useful for rendering operations where vertex sharing is not needed.
+         */
+        @Nullable
+        public final java.nio.ByteBuffer expandedIndices;
+
+        MeshData(java.nio.ByteBuffer positions,
+                 java.nio.ByteBuffer indices,
+                 java.nio.ByteBuffer expandedIndices) {
             this.positions = positions;
             this.indices = indices;
+            this.expandedIndices = expandedIndices;
         }
     }
 
@@ -417,13 +420,23 @@ public class FilamentAsset {
             return null;
         }
 
-        int positionCount = (int) info[0];
-        int indexCount = (int) info[1];
+        // info: [positionsPtr, positionsSize, indicesPtr, indicesSize, expandedIndicesPtr, expandedIndicesSize]
+        long positionsPtr = info[0];
+        long positionsSize = info[1];
+        long indicesPtr = info[2];
+        long indicesSize = info[3];
+        long expandedIndicesPtr = info[4];
+        long expandedIndicesSize = info[5];
 
-        java.nio.ByteBuffer positions = nGetMeshPositionsBuffer(mNativeObject, entityId);
-        java.nio.ByteBuffer indices = nGetMeshIndicesBuffer(mNativeObject, entityId);
+        // Create direct ByteBuffers from native pointers
+        java.nio.ByteBuffer positions = positionsPtr != 0 && positionsSize > 0
+            ? nNewDirectByteBuffer(positionsPtr, (int) positionsSize) : null;
+        java.nio.ByteBuffer indices = indicesPtr != 0 && indicesSize > 0
+            ? nNewDirectByteBuffer(indicesPtr, (int) indicesSize) : null;
+        java.nio.ByteBuffer expandedIndices = expandedIndicesPtr != 0 && expandedIndicesSize > 0
+            ? nNewDirectByteBuffer(expandedIndicesPtr, (int) expandedIndicesSize) : null;
 
-        return new MeshData(positionCount, indexCount, positions, indices);
+        return new MeshData(positions, indices, expandedIndices);
     }
 
     void clearNativeObject() {
@@ -473,6 +486,7 @@ public class FilamentAsset {
     private static native long nGetPickingRegistry(long nativeAsset);
 
     private static native long[] nGetMeshDataInfo(long nativeAsset, int entityId);
-    private static native java.nio.ByteBuffer nGetMeshPositionsBuffer(long nativeAsset, int entityId);
-    private static native java.nio.ByteBuffer nGetMeshIndicesBuffer(long nativeAsset, int entityId);
+
+    // Helper to create a direct ByteBuffer from native pointer
+    private static native java.nio.ByteBuffer nNewDirectByteBuffer(long address, int capacity);
 }

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
@@ -428,7 +428,29 @@ public class FilamentAsset {
         long expandedIndicesPtr = info[4];
         long expandedIndicesSize = info[5];
 
-        // Create direct ByteBuffers from native pointers
+        // Guard against silent truncation: ByteBuffer capacity is int-sized (max 2,147,483,647 bytes).
+        // Fail fast with null rather than producing a ByteBuffer with a truncated capacity
+        // that silently reads garbage beyond the true end of the data.
+        //   positions:        max ~178M vertices     (Integer.MAX_VALUE / 12 bytes per float3)
+        //   indices:          max ~178M triangles    (Integer.MAX_VALUE / 4 bytes per uint32 / 3 indices per triangle)
+        //   expandedIndices:  max ~178M triangles    (same as indices)
+        if (positionsSize > Integer.MAX_VALUE) {
+            android.util.Log.e("FilamentAsset",
+                    "getMeshData: positionsSize " + positionsSize + " exceeds Integer.MAX_VALUE for entity " + entityId);
+            return null;
+        }
+        if (indicesSize > Integer.MAX_VALUE) {
+            android.util.Log.e("FilamentAsset",
+                    "getMeshData: indicesSize " + indicesSize + " exceeds Integer.MAX_VALUE for entity " + entityId);
+            return null;
+        }
+        if (expandedIndicesSize > Integer.MAX_VALUE) {
+            android.util.Log.e("FilamentAsset",
+                    "getMeshData: expandedIndicesSize " + expandedIndicesSize + " exceeds Integer.MAX_VALUE for entity " + entityId);
+            return null;
+        }
+
+        // Safe to cast to int now — all sizes verified above to fit within Integer.MAX_VALUE.
         java.nio.ByteBuffer positions = positionsPtr != 0 && positionsSize > 0
             ? nNewDirectByteBuffer(positionsPtr, (int) positionsSize) : null;
         java.nio.ByteBuffer indices = indicesPtr != 0 && indicesSize > 0
@@ -487,6 +509,7 @@ public class FilamentAsset {
 
     private static native long[] nGetMeshDataInfo(long nativeAsset, int entityId);
 
-    // Helper to create a direct ByteBuffer from native pointer
+    // Creates a direct ByteBuffer from a native pointer.
+    // capacity is int — callers must verify the size fits within Integer.MAX_VALUE before calling.
     private static native java.nio.ByteBuffer nNewDirectByteBuffer(long address, int capacity);
 }

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -873,6 +873,26 @@ public:
 
     /**
      * Swaps only the index buffer for the given primitive while reusing the existing vertex buffer.
+     *
+     * This preserves the primitive type, vertex buffer and material that were originally set via
+     * Builder::geometry() or setGeometryAt(), and replaces only the index data.
+     *
+     * The \p offset and \p count parameters are expressed in indices, not bytes. The following
+     * constraints apply:
+     * - \p offset + \p count must not exceed the total number of indices in \p indices.
+     * - The index type of \p indices (e.g. 16-bit vs 32-bit) must be compatible with the index
+     *   type that was used when the primitive was created.
+     * - The sequence of indices referenced by [\p offset, \p offset + \p count) must be valid
+     *   for the primitive type configured for this primitive. For example, for triangle
+     *   primitives \p count should be a multiple of 3, and for line primitives a multiple of 2.
+     *
+     * @param instance       the renderable of interest
+     * @param primitiveIndex the primitive of interest within the renderable
+     * @param indices        the index buffer to use for this primitive
+     * @param offset         starting index within \p indices from which to begin reading indices
+     * @param count          number of indices to read from \p indices, starting at \p offset
+     *
+     * @see Builder::geometry(), setGeometryAt(), getIndexCountAt(), IndexBuffer
      */
     void swapIndexBufferAt(Instance instance, size_t primitiveIndex,
             IndexBuffer* UTILS_NONNULL indices, size_t offset, size_t count) noexcept;

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -871,6 +871,12 @@ public:
      */
     size_t getIndexCountAt(Instance instance, size_t primitiveIndex) const noexcept;
 
+    /**
+     * Swaps only the index buffer for the given primitive while reusing the existing vertex buffer.
+     */
+    void swapIndexBufferAt(Instance instance, size_t primitiveIndex,
+            IndexBuffer* UTILS_NONNULL indices, size_t offset, size_t count) noexcept;
+
     /*! \cond PRIVATE */
     template<typename T>
     struct is_supported_vector_type {

--- a/filament/src/RenderPrimitive.cpp
+++ b/filament/src/RenderPrimitive.cpp
@@ -70,6 +70,7 @@ void FRenderPrimitive::set(HwRenderPrimitiveFactory& factory, backend::DriverApi
     mVertexBufferInfoHandle = vertexBuffer->getVertexBufferInfoHandle();
 
     mPrimitiveType = type;
+    mVertexBuffer = vertexBuffer;
     mIndexOffset = offset;
     mIndexCount = count;
     mEnabledAttributes = enabledAttributes;

--- a/filament/src/RenderPrimitive.h
+++ b/filament/src/RenderPrimitive.h
@@ -54,6 +54,7 @@ public:
     const FMaterialInstance* getMaterialInstance() const noexcept { return mMaterialInstance; }
     backend::RenderPrimitiveHandle getHwHandle() const noexcept { return mHandle; }
     backend::VertexBufferInfoHandle getVertexBufferInfoHandle() const { return mVertexBufferInfoHandle; }
+    FVertexBuffer* getVertexBuffer() const noexcept { return mVertexBuffer; }
     uint32_t getIndexOffset() const noexcept { return mIndexOffset; }
     uint32_t getIndexCount() const noexcept { return mIndexCount; }
     uint32_t getMorphingBufferOffset() const noexcept { return mMorphingBufferOffset; }
@@ -83,6 +84,7 @@ private:
         FMaterialInstance const* mMaterialInstance = nullptr;
         backend::Handle<backend::HwRenderPrimitive> mHandle = {};
         backend::Handle<backend::HwVertexBufferInfo> mVertexBufferInfoHandle = {};
+        FVertexBuffer* mVertexBuffer = nullptr;
         uint32_t mIndexOffset = 0;
         uint32_t mIndexCount = 0;
         uint32_t mMorphingBufferOffset = 0;

--- a/filament/src/RenderableManager.cpp
+++ b/filament/src/RenderableManager.cpp
@@ -192,4 +192,10 @@ bool RenderableManager::getFogEnabled(RenderableManager::Instance instance) cons
     return downcast(this)->getFogEnabled(instance);
 }
 
+void RenderableManager::swapIndexBufferAt(Instance instance, size_t primitiveIndex,
+        IndexBuffer* indices, size_t offset, size_t count) noexcept {
+    downcast(this)->swapIndexBufferAt(instance, 0, primitiveIndex,
+            downcast(indices), offset, count);
+}
+
 } // namespace filament

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -877,6 +877,18 @@ void FRenderableManager::setGeometryAt(Instance instance, uint8_t level, size_t 
     }
 }
 
+void FRenderableManager::swapIndexBufferAt(Instance instance, uint8_t level, size_t primitiveIndex,
+        FIndexBuffer* indices, size_t offset, size_t count) noexcept {
+    if (instance) {
+        Slice<FRenderPrimitive>& primitives = getRenderPrimitives(instance, level);
+        if (primitiveIndex < primitives.size()) {
+            FRenderPrimitive& prim = primitives[primitiveIndex];
+            prim.set(mHwRenderPrimitiveFactory, mEngine.getDriverApi(),
+                    prim.getPrimitiveType(), prim.getVertexBuffer(), indices, offset, count);
+        }
+    }
+}
+
 void FRenderableManager::setBones(Instance ci,
         Bone const* UTILS_RESTRICT transforms, size_t boneCount, size_t offset) {
     if (ci) {

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -205,6 +205,8 @@ public:
     void setGeometryAt(Instance instance, uint8_t level, size_t primitiveIndex,
             PrimitiveType type, FVertexBuffer* vertices, FIndexBuffer* indices,
             size_t offset, size_t count) noexcept;
+    void swapIndexBufferAt(Instance instance, uint8_t level, size_t primitiveIndex,
+            FIndexBuffer* indices, size_t offset, size_t count) noexcept;
     void setBlendOrderAt(Instance instance, uint8_t level, size_t primitiveIndex, uint16_t blendOrder) noexcept;
     void setGlobalBlendOrderEnabledAt(Instance instance, uint8_t level, size_t primitiveIndex, bool enabled) noexcept;
     AttributeBitset getEnabledAttributesAt(Instance instance, uint8_t level, size_t primitiveIndex) const noexcept;

--- a/libs/gltfio/include/gltfio/PickingRegistry.h
+++ b/libs/gltfio/include/gltfio/PickingRegistry.h
@@ -51,6 +51,12 @@ struct MeshData {
     std::unique_ptr<tinybvh::BVH> bvh;          // BVH for accelerated ray tracing
     std::vector<tinybvh::bvhvec4> bvhVertices;  // Per-vertex data should be persisted, because tinybvh stores a pointer to this
 
+    // For AssetLoaderExtended:
+    // When vertices are duplicated during tangent generation, the index buffer is remapped.
+    // We store these expanded indices so triangle filtering can work correctly.
+    // The vertex buffer itself is reused from the renderable - we don't need to store positions.
+    std::vector<uint32_t> expandedIndices;       // Remapped indices for expanded vertex buffer
+
     MeshData() = default;
     MeshData(MeshData&&) noexcept = default;
     MeshData& operator=(MeshData&&) noexcept = default;
@@ -98,6 +104,20 @@ public:
     bool registerMesh(utils::Entity entity, const cgltf_mesh* mesh);
 
     /**
+     * Register expanded indices for an entity (used by AssetLoaderExtended).
+     * When vertices are duplicated during tangent generation, the renderable's index buffer
+     * is remapped to reference the expanded vertices. This method stores those remapped indices
+     * so triangle filtering can work correctly with the expanded vertex layout.
+     *
+     * @param entity The entity to update
+     * @param expandedIndices Remapped indices that match the renderable's vertex buffer
+     * @param indexCount Number of indices
+     * @return true if successful, false if entity not found
+     */
+    bool registerExpandedIndices(utils::Entity entity,
+                                  const uint32_t* expandedIndices, size_t indexCount);
+
+    /**
      * Perform ray-triangle intersection test against a specific entity's mesh.
      * Computes ray from screen coordinates and optionally skips triangles in specified ranges.
      *
@@ -140,6 +160,12 @@ public:
      * Clear all registered meshes.
      */
     void clear();
+
+    /**
+     * Log the total memory usage of indices and expandedIndices for all registered entities.
+     * Useful for debugging memory consumption after asset loading.
+     */
+    void logMemoryUsage() const;
 
 private:
     // Build BVH for a mesh

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -705,6 +705,19 @@ void FAssetLoader::createPrimitives(const cgltf_node* node, const char* name,
                     if (outputPrim.indices) {
                         fAsset->mIndexBuffers.push_back(outputPrim.indices);
                     }
+
+                    // Capture expanded indices from the slots for later registration with PickingRegistry
+                    // NOTE: expandedIndices is identical to the data that will be uploaded to outputPrim.indices
+                    // We store a CPU-side copy because slot.data will be freed after GPU upload,
+                    // but PickingRegistry needs CPU-side indices for proper triangle filtering
+                    for (const auto& slot : resourceInfo.slots) {
+                        if (slot.indices == outputPrim.indices && slot.data) {
+                            const uint32_t* expandedIndicesData = static_cast<const uint32_t*>(slot.data);
+                            size_t indexCount = slot.sizeInBytes / sizeof(uint32_t);
+                            outputPrim.expandedIndices.assign(expandedIndicesData, expandedIndicesData + indexCount);
+                            break;
+                        }
+                    }
                 }
             } else {
                 // Create a Filament VertexBuffer and IndexBuffer for this prim if we haven't

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -100,6 +100,13 @@ struct Primitive {
     MorphTargetBuffer* morphTargetBuffer = nullptr;
     uint32_t morphTargetOffset;
     std::vector<int> slotIndices;
+
+    // Temporary storage for expanded indices during loading (AssetLoaderExtended only)
+    // NOTE: This is mesh-level storage because Primitives are cached and reused across
+    // multiple nodes. The indices are extracted in createPrimitives() (where slot.data
+    // is available) and then copied per-entity to PickingRegistry in ResourceLoader.
+    // Cleared immediately after copying to save memory.
+    std::vector<uint32_t> expandedIndices;
 };
 using MeshCache = utils::FixedCapacityVector<utils::FixedCapacityVector<Primitive>>;
 

--- a/libs/gltfio/src/PickingRegistry.cpp
+++ b/libs/gltfio/src/PickingRegistry.cpp
@@ -170,6 +170,24 @@ bool PickingRegistry::registerMesh(const Entity entity, const cgltf_mesh* mesh) 
     return true;
 }
 
+bool PickingRegistry::registerExpandedIndices(const Entity entity,
+                                              const uint32_t* expandedIndices, size_t indexCount) {
+    auto it = mMeshes.find(entity);
+    if (it == mMeshes.end()) {
+        slog.w << "PickingRegistry: Cannot register expanded indices for unknown entity " << entity.getId() << io::endl;
+        return false;
+    }
+
+    MeshData& meshData = it->second;
+
+    // Store the expanded indices that match the renderable's vertex buffer
+    // The vertex buffer is owned by the renderable - we don't need to store positions
+    // These indices will be returned by nGetMeshIndicesBuffer for use in triangle filtering
+    meshData.expandedIndices.assign(expandedIndices, expandedIndices + indexCount);
+
+    return true;
+}
+
 // ============================================================================
 // BVH Construction
 // ============================================================================
@@ -319,4 +337,55 @@ bool PickingRegistry::computeScreenRay(View* view, int2 position,
 void PickingRegistry::clear() {
     mMeshes.clear();
 }
+
+void PickingRegistry::logMemoryUsage() const {
+#ifndef NDEBUG
+    if (mMeshes.empty()) {
+        slog.i << "PickingRegistry: No entities registered" << io::endl;
+        return;
+    }
+
+    size_t totalOriginalIndicesBytes = 0;
+    size_t totalExpandedIndicesBytes = 0;
+    size_t entitiesWithExpandedIndices = 0;
+
+    for (const auto& [entity, meshData] : mMeshes) {
+        // Calculate memory for original indices
+        size_t originalBytes = meshData.indices.size() * sizeof(uint32_t);
+        totalOriginalIndicesBytes += originalBytes;
+
+        // Calculate memory for expanded indices (if present)
+        if (!meshData.expandedIndices.empty()) {
+            size_t expandedBytes = meshData.expandedIndices.size() * sizeof(uint32_t);
+            totalExpandedIndicesBytes += expandedBytes;
+            entitiesWithExpandedIndices++;
+        }
+    }
+
+    // Convert to KB and MB for readability
+    double totalOriginalKB = totalOriginalIndicesBytes / 1024.0;
+    double totalOriginalMB = totalOriginalKB / 1024.0;
+    double totalExpandedKB = totalExpandedIndicesBytes / 1024.0;
+    double totalExpandedMB = totalExpandedKB / 1024.0;
+    double totalBytes = totalOriginalIndicesBytes + totalExpandedIndicesBytes;
+    double totalKB = totalBytes / 1024.0;
+    double totalMB = totalKB / 1024.0;
+
+    slog.i << "========================================" << io::endl;
+    slog.i << "PickingRegistry Memory Usage Summary" << io::endl;
+    slog.i << "========================================" << io::endl;
+    slog.i << "Total entities: " << mMeshes.size() << io::endl;
+    slog.i << "Entities with expanded indices: " << entitiesWithExpandedIndices << io::endl;
+    slog.i << "----------------------------------------" << io::endl;
+    slog.i << "Original indices: " << totalOriginalIndicesBytes << " bytes "
+           << "(" << totalOriginalKB << " KB, " << totalOriginalMB << " MB)" << io::endl;
+    slog.i << "Expanded indices: " << totalExpandedIndicesBytes << " bytes "
+           << "(" << totalExpandedKB << " KB, " << totalExpandedMB << " MB)" << io::endl;
+    slog.i << "----------------------------------------" << io::endl;
+    slog.i << "TOTAL: " << totalBytes << " bytes "
+           << "(" << totalKB << " KB, " << totalMB << " MB)" << io::endl;
+    slog.i << "========================================" << io::endl;
+#endif
+}
+
 } // namespace filament::gltfio

--- a/libs/gltfio/src/PickingRegistry.cpp
+++ b/libs/gltfio/src/PickingRegistry.cpp
@@ -180,9 +180,27 @@ bool PickingRegistry::registerExpandedIndices(const Entity entity,
 
     MeshData& meshData = it->second;
 
-    // Store the expanded indices that match the renderable's vertex buffer
-    // The vertex buffer is owned by the renderable - we don't need to store positions
-    // These indices will be returned by nGetMeshIndicesBuffer for use in triangle filtering
+    // registerMesh() must be called first — it populates meshData.indices.
+    // If indices is empty, registerMesh() was either not called or produced no geometry.
+    if (meshData.indices.empty()) {
+        slog.w << "PickingRegistry::registerExpandedIndices: entity " << entity.getId()
+               << " has no indices. registerMesh() must be called before registerExpandedIndices()."
+               << io::endl;
+        return false;
+    }
+
+    // Validate that the expanded index count matches the original index count.
+    // If these diverge, triangle filtering will be inconsistent because both operate
+    // on the same index-slot ranges derived from meshData.indices.
+    if (indexCount != meshData.indices.size()) {
+        slog.w << "PickingRegistry::registerExpandedIndices: size mismatch for entity "
+               << entity.getId()
+               << ": expected " << meshData.indices.size()
+               << " (from registerMesh) but got " << indexCount
+               << ". Expanded indices not registered." << io::endl;
+        return false;
+    }
+
     meshData.expandedIndices.assign(expandedIndices, expandedIndices + indexCount);
 
     return true;

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -463,8 +463,51 @@ bool ResourceLoader::loadResources(FFilamentAsset* asset, bool async) {
     // In both cases, buffer->data is now valid and we can read vertex positions
     for (const auto& [entity, mesh] : asset->mPendingMeshRegistrations) {
         asset->mPickingRegistry.registerMesh(entity, mesh);
+
+        // For AssetLoaderExtended: also register expanded indices if available
+        // This allows triangle filtering to work correctly with expanded vertex buffers
+        // NOTE: Multiple entities can share the same primitive (via mMeshCache).
+        // Since assign() copies the data, all entities will copy from the shared expandedIndices.
+        // We clear all primitives after the loop to avoid clearing while other entities still need it.
+        const cgltf_size meshIndex = mesh - gltf->meshes;
+        if (meshIndex < asset->mMeshCache.size()) {
+            const auto& prims = asset->mMeshCache[meshIndex];
+
+            // Warn if mesh has multiple primitives - we only handle single-primitive meshes
+            if (prims.size() > 1) {
+                slog.w << "Mesh '" << (mesh->name ? mesh->name : "<unnamed>")
+                       << "' has " << prims.size() << " primitives. "
+                       << "ExpandedIndices registration only supports single-primitive meshes. "
+                       << "Triangle filtering may not work correctly for this mesh." << io::endl;
+            }
+
+            // For simplicity, we only handle single-primitive meshes for now
+            // Multi-primitive meshes would need more complex index concatenation
+            // When we merge meshes using gltfpack, it creates separate mesh for each primitive,
+            // so this is not a problem in practice.
+            // https://github.com/Fieldwire/meshoptimizer/blob/34ea6b0f1041794b37fd33a512999c44a3704470/gltf/parsegltf.cpp#L197
+            if (prims.size() == 1 && !prims[0].expandedIndices.empty()) {
+                asset->mPickingRegistry.registerExpandedIndices(entity,
+                    prims[0].expandedIndices.data(),
+                    prims[0].expandedIndices.size());
+            }
+        }
     }
     asset->mPendingMeshRegistrations.clear();
+
+    // Clear expandedIndices from all primitives in mMeshCache to save memory
+    // Now that all entities have been registered, we can safely free this temporary data
+    for (auto& primList : asset->mMeshCache) {
+        for (auto& prim : primList) {
+            if (!prim.expandedIndices.empty()) {
+                prim.expandedIndices.clear();
+                prim.expandedIndices.shrink_to_fit();
+            }
+        }
+    }
+
+    // Log memory usage of PickingRegistry after all entities are registered
+    asset->mPickingRegistry.logMemoryUsage();
 
     createSkins(gltf, pImpl->mNormalizeSkinningWeights, asset->mSkins);
 

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -496,13 +496,9 @@ bool ResourceLoader::loadResources(FFilamentAsset* asset, bool async) {
     asset->mPendingMeshRegistrations.clear();
 
     // Clear expandedIndices from all primitives in mMeshCache to save memory
-    // Now that all entities have been registered, we can safely free this temporary data
     for (auto& primList : asset->mMeshCache) {
         for (auto& prim : primList) {
-            if (!prim.expandedIndices.empty()) {
-                prim.expandedIndices.clear();
-                prim.expandedIndices.shrink_to_fit();
-            }
+            prim.expandedIndices = {};
         }
     }
 


### PR DESCRIPTION
https://fieldwire.atlassian.net/browse/ME-6448

This PR introduces the swapIndexBufferAt API in RenderableManager for selectively hiding subsets of triangles in a mesh without recreating the entire renderable.

### Use Case: Selective Triangle Visibility

1. **Pick individual triangles** from a 3D model
2. **Hide/show subsets of triangles** dynamically (e.g., hide all triangles in a range)
3. **Preserve the original visual appearance** (materials, lighting, textures)
4. **Maintain performance** even with millions of triangles

#### ❌ **Option 1: Recreate Both VertexBuffer and IndexBuffer**
```cpp
// Create new vertex buffer with only visible triangles
VertexBuffer* newVB = createVertexBuffer(visibleVertices);
IndexBuffer* newIB = createIndexBuffer(visibleIndices);
setGeometryAt(instance, 0, newVB, newIB);
```

**Problems:**
- ⚠️ **Requires regenerating all vertex attributes** (positions, normals, tangents, UVs, colors)
- ⚠️ **Risk of visual artifacts** if normals/tangents aren't regenerated identically
- ⚠️ **Memory overhead** - duplicate vertex data even when only indices change
- ⚠️ **CPU cost** - vertex attribute generation is expensive

#### ❌ **Option 2: Create New Renderable**
```cpp
Entity newEntity = createEntity();
// Build new renderable with subset of triangles
RenderableManager::Builder(1)
    .geometry(0, TRIANGLES, originalVB, filteredIB)
    .material(0, originalMaterial)
    .build(engine, newEntity);
```

**Problems:**
- ⚠️ Requires recreating the material of the selected object which is non-trivial.  


## Solution: `swapIndexBufferAt` API
When hiding triangles, we only need to change **which triangles are rendered**, not **how vertices are processed** and not the material

- ✅ **Reuse existing VertexBuffer** - no vertex data duplication
- ✅ **Preserve material/lighting** - exact same visual appearance
- ✅ **Minimal CPU cost** - only rebuild index buffer
- ✅ **Low memory overhead** - only store index remapping data


## The `expandedIndices` Concept

### Why It's Needed, why not use the existing `indices` from MeshData

When `AssetLoaderExtended` processes a glTF mesh, it may **expand vertices** to support per-face attributes:

```
Original glTF:
  100 positions (shared across triangles)
  180 triangles (540 indices referencing 0-99)

After AssetLoaderExtended (with face normals/tangents):
  540 expanded vertices (duplicated for per-face attributes)
  180 triangles (540 indices referencing 0-539)
```

**The Problem:**
- **PickingRegistry** uses **original positions** (100 vertices) for BVH ray tracing
- **RenderableManager** uses **expanded vertices** (540 vertices) for rendering
- **Index buffers don't match!**

```
Triangle picked at original index 50:
  PickingRegistry indices: [150, 151, 152] (references positions 0-99)
  Renderable indices: [150, 151, 152] (references expanded vertices 0-539)
  ❌ Mismatch! Can't directly use picking indices for rendering.
```


## Memory 

**Per Primitive:**
```cpp
expandedIndices: indexCount × 4 bytes

50,000 triangles = 150,000 indices × 4 bytes = ~600 KB // 600KB * 2 for original indices and expandedIndices
```


 