### PR TITLE
toggleable picking

### DIFF
--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -134,7 +134,7 @@ class ModelViewer(
         view.camera = camera
 
         materialProvider = UbershaderProvider(engine)
-        assetLoader = AssetLoader(engine, materialProvider, EntityManager.get(), "", "UndefinedObjectName")
+        assetLoader = AssetLoader(engine, materialProvider, EntityManager.get(), false, true)
         resourceLoader = ResourceLoader(engine, normalizeSkinningWeights)
 
         // Always add a direct light source since it is required for shadowing.

--- a/android/gltfio-android/src/main/cpp/AssetLoader.cpp
+++ b/android/gltfio-android/src/main/cpp/AssetLoader.cpp
@@ -270,17 +270,35 @@ Java_com_google_android_filament_gltfio_AssetLoader_nCreateAsset(JNIEnv* env, jc
 
 
 extern "C" JNIEXPORT jlong JNICALL
-Java_com_google_android_filament_gltfio_AssetLoader_nCreateAssetLoaderExtended(JNIEnv* env, jclass,
-                                                                               jlong nativeEngine, jobject provider, jlong nativeEntities, jstring filePath, jstring defaultNodeName) {
-    Engine* engine = (Engine*) nativeEngine;
+Java_com_google_android_filament_gltfio_AssetLoader_nFwCreateAssetLoader(
+    JNIEnv* env,
+    jclass jlass,
+    const jlong nativeEngine,
+    jobject provider,
+    jlong nativeEntities,
+    jboolean generateNormals,
+    jboolean trianglePickingEnabled
+) {
+    jstring defaultNodeName = env->NewStringUTF("Unknown Object");
+    if (!generateNormals && !trianglePickingEnabled) {
+        return Java_com_google_android_filament_gltfio_AssetLoader_nCreateAssetLoader(
+            env,
+            jlass,
+            nativeEngine,
+            provider,
+            nativeEntities,
+            defaultNodeName
+        );
+    }
+
+    Engine* engine = reinterpret_cast<Engine *>(nativeEngine);
     MaterialProvider* materialProvider = nullptr;
 
     // First check for a fast path that passes a native MaterialProvider into the loader.
     // This drastically reduces the number of JNI calls while the asset is being loaded.
     jclass klass = env->GetObjectClass(provider);
-    jmethodID getNativeObject = env->GetMethodID(klass, "getNativeObject", "()J");
-    if (getNativeObject) {
-        materialProvider = (MaterialProvider*) env->CallLongMethod(provider, getNativeObject);
+    if (jmethodID getNativeObject = env->GetMethodID(klass, "getNativeObject", "()J")) {
+        materialProvider = reinterpret_cast<MaterialProvider *>(env->CallLongMethod(provider, getNativeObject));
     } else {
         env->ExceptionClear();
     }
@@ -289,26 +307,25 @@ Java_com_google_android_filament_gltfio_AssetLoader_nCreateAssetLoaderExtended(J
         materialProvider = new JavaMaterialProvider(env, provider);
     }
 
-    EntityManager* entities = (EntityManager*) nativeEntities;
+    EntityManager* entities = reinterpret_cast<EntityManager *>(nativeEntities);
     NameComponentManager* names = new NameComponentManager(*entities);
 
-    const char *nativeFilePath = env->GetStringUTFChars(filePath, nullptr);
     const char *nativeDefaultNodeName = env->GetStringUTFChars(defaultNodeName, nullptr);
 
     AssetConfigurationExtended ext = {
-            .gltfPath = nativeFilePath
+        .gltfPath = "",
+        .trianglePickingEnabled = static_cast<bool>(trianglePickingEnabled)
     };
 
-    AssetConfiguration config = {
-            .engine = engine,
-            .materials = materialProvider,
-            .names = names,
-            .defaultNodeName = const_cast<char *>(nativeDefaultNodeName),
-            .ext = &ext,
+    const AssetConfiguration config = {
+        .engine = engine,
+        .materials = materialProvider,
+        .names = names,
+        .defaultNodeName = const_cast<char *>(nativeDefaultNodeName),
+        .ext = &ext,
     };
 
-    env->ReleaseStringUTFChars(filePath, nativeFilePath);
-    env->ReleaseStringUTFChars(defaultNodeName,  nativeDefaultNodeName);
+    env->ReleaseStringUTFChars(defaultNodeName, nativeDefaultNodeName);
 
     return (jlong) AssetLoader::create(config);
 }

--- a/android/gltfio-android/src/main/cpp/AssetLoader.cpp
+++ b/android/gltfio-android/src/main/cpp/AssetLoader.cpp
@@ -280,8 +280,8 @@ Java_com_google_android_filament_gltfio_AssetLoader_nFwCreateAssetLoader(
     jboolean trianglePickingEnabled
 ) {
     constexpr const char* kDefaultNodeName = "Unknown Object";
-    jstring defaultNodeName = env->NewStringUTF(kDefaultNodeName);
     if (!generateNormals && !trianglePickingEnabled) {
+        jstring defaultNodeName = env->NewStringUTF(kDefaultNodeName);
         return Java_com_google_android_filament_gltfio_AssetLoader_nCreateAssetLoader(
             env,
             jlass,

--- a/android/gltfio-android/src/main/cpp/AssetLoader.cpp
+++ b/android/gltfio-android/src/main/cpp/AssetLoader.cpp
@@ -320,7 +320,7 @@ Java_com_google_android_filament_gltfio_AssetLoader_nFwCreateAssetLoader(
         .engine = engine,
         .materials = materialProvider,
         .names = names,
-        .defaultNodeName = kDefaultNodeName,
+        .defaultNodeName = const_cast<char*>(kDefaultNodeName),
         .ext = &ext,
     };
 

--- a/android/gltfio-android/src/main/cpp/AssetLoader.cpp
+++ b/android/gltfio-android/src/main/cpp/AssetLoader.cpp
@@ -279,7 +279,8 @@ Java_com_google_android_filament_gltfio_AssetLoader_nFwCreateAssetLoader(
     jboolean generateNormals,
     jboolean trianglePickingEnabled
 ) {
-    jstring defaultNodeName = env->NewStringUTF("Unknown Object");
+    constexpr const char* kDefaultNodeName = "Unknown Object";
+    jstring defaultNodeName = env->NewStringUTF(kDefaultNodeName);
     if (!generateNormals && !trianglePickingEnabled) {
         return Java_com_google_android_filament_gltfio_AssetLoader_nCreateAssetLoader(
             env,
@@ -310,8 +311,6 @@ Java_com_google_android_filament_gltfio_AssetLoader_nFwCreateAssetLoader(
     EntityManager* entities = reinterpret_cast<EntityManager *>(nativeEntities);
     NameComponentManager* names = new NameComponentManager(*entities);
 
-    const char *nativeDefaultNodeName = env->GetStringUTFChars(defaultNodeName, nullptr);
-
     AssetConfigurationExtended ext = {
         .gltfPath = "",
         .trianglePickingEnabled = static_cast<bool>(trianglePickingEnabled)
@@ -321,11 +320,9 @@ Java_com_google_android_filament_gltfio_AssetLoader_nFwCreateAssetLoader(
         .engine = engine,
         .materials = materialProvider,
         .names = names,
-        .defaultNodeName = const_cast<char *>(nativeDefaultNodeName),
+        .defaultNodeName = kDefaultNodeName,
         .ext = &ext,
     };
-
-    env->ReleaseStringUTFChars(defaultNodeName, nativeDefaultNodeName);
 
     return (jlong) AssetLoader::create(config);
 }

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
@@ -121,12 +121,11 @@ public class AssetLoader {
      * @param engine the engine that the loader should pass to builder objects
      * @param provider an object that provides Filament materials corresponding to glTF materials
      * @param entities the {@link EntityManager} that should be used to create entities
-     * @param generateNormals selects the extended loader path and requests normal generation;
-     *                        current implementations may generate normals even if this flag is
-     *                        ignored by the native loader
-     * @param trianglePickingEnabled enables creation of data structures used for triangle-based
-     *                               picking on the loaded asset, if supported by the native
-     *                               loader implementation
+     * @param generateNormals if true, selects the extended loader path;
+     *                        normal generation is not currently implemented and
+     *                        this flag has no effect on geometry beyond path selection
+     * @param trianglePickingEnabled enables creation of BVH and picking data
+     *                               structures for triangle-level picking
      */
     public AssetLoader(
         @NonNull Engine engine,

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
@@ -121,9 +121,11 @@ public class AssetLoader {
      * @param engine the engine that the loader should pass to builder objects
      * @param provider an object that provides Filament materials corresponding to glTF materials
      * @param entities the {@link EntityManager} that should be used to create entities
-     * @param generateNormals if true, selects the extended loader path;
-     *                        normal generation is not currently implemented and
-     *                        this flag has no effect on geometry beyond path selection
+     * @param generateNormals if true, selects the extended loader path. The extended path can
+     *                        compute flat normals (and corresponding tangents) for primitives
+     *                        that do not provide them, as part of the native loading pipeline.
+     *                        This flag therefore influences both path selection and whether
+     *                        normals may be generated when they are missing in the source data.
      * @param trianglePickingEnabled enables creation of BVH and picking data
      *                               structures for triangle-level picking
      */

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
@@ -103,16 +103,23 @@ public class AssetLoader {
         mMaterialCache = provider;
     }
 
-    public AssetLoader(@NonNull Engine engine, @NonNull MaterialProvider provider,
-                       @NonNull EntityManager entities, String filePath, String defaultNodeName) {
-
+    public AssetLoader(
+        @NonNull Engine engine,
+        @NonNull MaterialProvider provider,
+        @NonNull EntityManager entities,
+        boolean generateNormals,
+        boolean trianglePickingEnabled
+    ) {
         long nativeEngine = engine.getNativeObject();
         long nativeEntities = entities.getNativeObject();
-        if (filePath == null) {
-            mNativeObject = nCreateAssetLoader(nativeEngine, provider, nativeEntities, defaultNodeName);
-        } else {
-            mNativeObject = nCreateAssetLoaderExtended(nativeEngine, provider, nativeEntities, filePath, defaultNodeName);
-        }
+
+        mNativeObject = nFwCreateAssetLoader(
+            nativeEngine,
+            provider,
+            nativeEntities,
+            generateNormals,
+            trianglePickingEnabled
+        );
 
         if (mNativeObject == 0) {
             throw new IllegalStateException("Unable to parse glTF asset.");
@@ -209,8 +216,14 @@ public class AssetLoader {
 
     private static native long nCreateAssetLoader(long nativeEngine, Object provider,
             long nativeEntities, String defaultNodeName);
-    private static native long nCreateAssetLoaderExtended(long nativeEngine, Object provider,
-                                                          long nativeEntities, String filePath, String defaultNodeName);
+    private static native long nFwCreateAssetLoader(
+        long nativeEngine,
+        Object provider,
+        long nativeEntities,
+        boolean generateNormals,
+        boolean trianglePickingEnabled
+    );
+
     private static native void nDestroyAssetLoader(long nativeLoader);
     private static native long nCreateAsset(long nativeLoader, Buffer buffer, int remaining);
     private static native long nCreateInstancedAsset(long nativeLoader, Buffer buffer, int remaining,

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
@@ -103,6 +103,31 @@ public class AssetLoader {
         mMaterialCache = provider;
     }
 
+    /**
+     * Constructs an <code>AssetLoader</code> that uses the extended loader configuration.
+     * <p>
+     * This overload allows opting into additional features such as triangle picking support.
+     * Note that the {@code generateNormals} flag currently selects the extended loader behavior
+     * and may not provide fine-grained control over whether normals are generated in all cases;
+     * the underlying implementation may still generate normals unconditionally when using the
+     * extended loader path.
+     * </p>
+     * <p>
+     * Unlike the {@link #AssetLoader(Engine, MaterialProvider, EntityManager, String)} overload,
+     * this constructor does not accept a {@code defaultNodeName}. When using the extended loader
+     * configuration, the default node name (if any) is determined by the native implementation.
+     * </p>
+     *
+     * @param engine the engine that the loader should pass to builder objects
+     * @param provider an object that provides Filament materials corresponding to glTF materials
+     * @param entities the {@link EntityManager} that should be used to create entities
+     * @param generateNormals selects the extended loader path and requests normal generation;
+     *                        current implementations may generate normals even if this flag is
+     *                        ignored by the native loader
+     * @param trianglePickingEnabled enables creation of data structures used for triangle-based
+     *                               picking on the loaded asset, if supported by the native
+     *                               loader implementation
+     */
     public AssetLoader(
         @NonNull Engine engine,
         @NonNull MaterialProvider provider,

--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -50,6 +50,11 @@ struct AssetConfigurationExtended {
     //! gltfio/ResourceLoader.h
     char const* gltfPath;
 
+    //! When true, the BVH is built for triangle picking (ray casting). Set false to suppress
+    //! BVH construction for models where picking is not needed (e.g. full-model entity picking,
+    //! or PickMode.None). Suppressing BVH avoids OOM on large models (150K+ objects).
+    bool trianglePickingEnabled = false;
+
     //! Client can use this method to check if the extended implementation is supported on their
     //! platform or not.
     static bool isSupported();

--- a/libs/gltfio/include/gltfio/PickingRegistry.h
+++ b/libs/gltfio/include/gltfio/PickingRegistry.h
@@ -23,6 +23,7 @@
 #include <vector>
 #include <unordered_map>
 #include <memory>
+#include <functional>
 
 // Forward declaration of cgltf types
 struct cgltf_mesh;
@@ -92,6 +93,30 @@ public:
     // Enable move operations (implemented in .cpp where MeshData is complete)
     PickingRegistry(PickingRegistry&&) noexcept;
     PickingRegistry& operator=(PickingRegistry&&) noexcept;
+
+    // Defer mesh registration for picking until ResourceLoader has loaded cgltf buffers
+    // At this point, buffer->data is NULL, so we can't read vertex positions yet
+    // Store the entity-mesh pair to be processed later in ResourceLoader::loadResources()
+    void enqueueMesh(utils::Entity entity, const cgltf_mesh* mesh) {
+        pendingRegistrations.emplace_back(entity, mesh);
+    }
+
+    /**
+     * Register all queued meshes into the registry, then clear the queue.
+     * Callbacks allow callers to provide mesh data without exposing MeshCache to this header.
+     *
+     * @param gltfMeshes       base pointer for mesh index arithmetic
+     * @param meshCacheSize    number of entries in the mesh cache
+     * @param getPrimsSize     (meshIndex) -> number of primitives for that mesh
+     * @param getExpandedIndices (meshIndex, primIndex) -> reference to expandedIndices vector for that primitive
+     * @return true if all meshes registered successfully; false if any failed (sets mBvhBuildFailed on asset)
+     */
+    bool commitRegistrations(
+        const cgltf_mesh* gltfMeshes,
+        size_t meshCacheSize,
+        const std::function<size_t(size_t)>& getPrimsSize,
+        const std::function<std::vector<uint32_t>&(size_t, size_t)>& getExpandedIndices
+    );
 
     /**
      * Register a mesh from a GLTF mesh structure.
@@ -175,6 +200,10 @@ private:
     // Returns true if successful, false otherwise
     static bool computeScreenRay(View* view, math::int2 position,
                                  math::float3& outOrigin, math::float3& outDirection);
+
+    // Queued during node traversal (AssetLoader); consumed by commitRegistrations().
+    // Only populated when enabled == true.
+    std::vector<std::pair<utils::Entity, const cgltf_mesh*>> pendingRegistrations;
 
     // Entity to mesh data mapping
     std::unordered_map<utils::Entity, MeshData, utils::Entity::Hasher> mMeshes;

--- a/libs/gltfio/include/gltfio/PickingRegistry.h
+++ b/libs/gltfio/include/gltfio/PickingRegistry.h
@@ -109,7 +109,7 @@ public:
      * @param meshCacheSize    number of entries in the mesh cache
      * @param getPrimsSize     (meshIndex) -> number of primitives for that mesh
      * @param getExpandedIndices (meshIndex, primIndex) -> reference to expandedIndices vector for that primitive
-     * @return true if all meshes registered successfully; false if any failed (sets mBvhBuildFailed on asset)
+     * @return true if all meshes registered successfully; false if any failed; failures are reported via logging
      */
     bool commitRegistrations(
         const cgltf_mesh* gltfMeshes,

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -272,6 +272,7 @@ struct FAssetLoader : public AssetLoader {
                     << "Extend asset loading is not supported on this platform";
             mLoaderExtended = std::make_unique<AssetLoaderExtended>(
                     *config.ext, config.engine, mMaterials);
+            mTrianglePickingEnabled = config.ext->trianglePickingEnabled;
         }
     }
 
@@ -359,6 +360,9 @@ public:
 
 public:
     std::unique_ptr<AssetLoaderExtended> mLoaderExtended;
+
+private:
+    bool mTrianglePickingEnabled = false;
 };
 
 FILAMENT_DOWNCAST(AssetLoader)
@@ -489,7 +493,8 @@ FFilamentAsset* FAssetLoader::createRootAsset(const cgltf_data* srcAsset) {
 
     mDummyBufferObject = nullptr;
     FFilamentAsset* fAsset = new FFilamentAsset(&mEngine, mNameManager, &mEntityManager,
-            &mNodeManager, &mTrsTransformManager, srcAsset, (bool) mLoaderExtended);
+            &mNodeManager, &mTrsTransformManager, srcAsset, (bool) mLoaderExtended,
+            mTrianglePickingEnabled);
 
     // It is not an error for a glTF file to have zero scenes.
     fAsset->mScenes.clear();
@@ -923,11 +928,8 @@ void FAssetLoader::createRenderable(const cgltf_node* node, Entity entity, const
         mRenderableManager.setMorphWeights(renderable, weights.data(), size);
     }
 
-    // Defer mesh registration for picking until ResourceLoader has loaded cgltf buffers
-    // At this point, buffer->data is NULL, so we can't read vertex positions yet
-    // Store the entity-mesh pair to be processed later in ResourceLoader::loadResources()
-    if (node->mesh) {
-        fAsset->mPendingMeshRegistrations.emplace_back(entity, node->mesh);
+    if (const auto pickingRegistry = fAsset->getPickingRegistry()) {
+        pickingRegistry->enqueueMesh(entity, node->mesh);
     }
 }
 

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -712,16 +712,18 @@ void FAssetLoader::createPrimitives(const cgltf_node* node, const char* name,
                         fAsset->mIndexBuffers.push_back(outputPrim.indices);
                     }
 
-                    // Capture expanded indices from the slots for later registration with PickingRegistry
-                    // NOTE: expandedIndices is identical to the data that will be uploaded to outputPrim.indices
-                    // We store a CPU-side copy because slot.data will be freed after GPU upload,
-                    // but PickingRegistry needs CPU-side indices for proper triangle filtering
-                    for (const auto& slot : resourceInfo.slots) {
-                        if (slot.indices == outputPrim.indices && slot.data) {
-                            const uint32_t* expandedIndicesData = static_cast<const uint32_t*>(slot.data);
-                            size_t indexCount = slot.sizeInBytes / sizeof(uint32_t);
-                            outputPrim.expandedIndices.assign(expandedIndicesData, expandedIndicesData + indexCount);
-                            break;
+                    if (fAsset->mTrianglePickingEnabled) {
+                        // Capture expanded indices from the slots for later registration with PickingRegistry
+                        // NOTE: expandedIndices is identical to the data that will be uploaded to outputPrim.indices
+                        // We store a CPU-side copy because slot.data will be freed after GPU upload,
+                        // but PickingRegistry needs CPU-side indices for proper triangle filtering
+                        for (const auto& slot : resourceInfo.slots) {
+                            if (slot.indices == outputPrim.indices && slot.data) {
+                                const uint32_t* expandedIndicesData = static_cast<const uint32_t*>(slot.data);
+                                size_t indexCount = slot.sizeInBytes / sizeof(uint32_t);
+                                outputPrim.expandedIndices.assign(expandedIndicesData, expandedIndicesData + indexCount);
+                                break;
+                            }
                         }
                     }
                 }

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -119,12 +119,12 @@ struct FFilamentAsset : public FilamentAsset {
     FFilamentAsset(Engine* engine, utils::NameComponentManager* names,
             utils::EntityManager* entityManager, NodeManager* nodeManager,
             TrsTransformManager* trsTransformManager, const cgltf_data* srcAsset,
-            bool useExtendedAlgo) :
+            bool useExtendedAlgo, const bool trianglePickingEnabled) :
             mEngine(engine), mNameManager(names), mEntityManager(entityManager),
             mNodeManager(nodeManager), mTrsTransformManager(trsTransformManager),
             mSourceAsset(new SourceAsset {(cgltf_data*)srcAsset}),
             mTextures(srcAsset->textures_count),
-            mMeshCache(srcAsset->meshes_count) {
+            mMeshCache(srcAsset->meshes_count), mTrianglePickingEnabled(trianglePickingEnabled) {
         if (!useExtendedAlgo) {
             mResourceInfo = ResourceInfo{};
         } else {
@@ -240,6 +240,10 @@ struct FFilamentAsset : public FilamentAsset {
             SceneMask sceneFilter) const;
 
     PickingRegistry* getPickingRegistry() noexcept {
+        if (!mTrianglePickingEnabled) {
+            return nullptr;
+        }
+
         return &mPickingRegistry;
     }
 
@@ -299,6 +303,8 @@ struct FFilamentAsset : public FilamentAsset {
     const cgltf_accessor mGenerateNormals = {};
     const cgltf_accessor mGenerateTangents = {};
 
+    const bool mTrianglePickingEnabled;
+
     // Encapsulates reference-counted source data, which includes the cgltf hierachy
     // and potentially also includes buffer data that can be uploaded to the GPU.
     struct SourceAsset {
@@ -336,9 +342,6 @@ struct FFilamentAsset : public FilamentAsset {
 
     // The mapping from cgltf_mesh to VertexBuffer* (etc) is required when creating new instances.
     MeshCache mMeshCache;
-
-    // Pending mesh registrations for picking - processed after buffers are loaded
-    std::vector<std::pair<utils::Entity, const cgltf_mesh*>> mPendingMeshRegistrations;
 
     // Asset information that is produced by AssetLoader and consumed by ResourceLoader:
     struct ResourceInfo {
@@ -390,6 +393,7 @@ struct FFilamentAsset : public FilamentAsset {
 
     std::variant<ResourceInfo, ResourceInfoExtended> mResourceInfo;
 
+private:
     /**
      * Picking registry for triangle-level ray intersection testing.
      * Automatically populated during asset loading.

--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -44,7 +44,9 @@ FFilamentAsset::~FFilamentAsset() {
     delete mWireframe;
 
     // Start fresh
-    mPickingRegistry.clear();
+    if (const auto pickingRegistry = getPickingRegistry()) {
+        pickingRegistry->clear();
+    }
 
     // Destroy name components.
     if (mNameManager) {

--- a/libs/gltfio/src/PickingRegistry.cpp
+++ b/libs/gltfio/src/PickingRegistry.cpp
@@ -84,6 +84,62 @@ PickingRegistry& PickingRegistry::operator=(PickingRegistry&&) noexcept = defaul
 // Mesh Registration
 // ============================================================================
 
+bool PickingRegistry::commitRegistrations(
+    const cgltf_mesh *gltfMeshes,
+    const size_t meshCacheSize,
+    const std::function<size_t(size_t)> &getPrimsSize,
+    const std::function<std::vector<uint32_t>&(size_t, size_t)> &getExpandedIndices
+) {
+    if (pendingRegistrations.empty()) {
+        return true;
+    }
+
+    bool allSucceeded = true;
+
+    for (const auto& [entity, mesh] : pendingRegistrations) {
+        if (!registerMesh(entity, mesh)) {
+            allSucceeded = false;
+            continue;
+        }
+
+        const cgltf_size meshIndex = mesh - gltfMeshes;
+        if (meshIndex < meshCacheSize) {
+            const auto primsSize = getPrimsSize(meshIndex);
+
+            if (primsSize > 1) {
+                slog.w << "Mesh '" << (mesh->name ? mesh->name : "<unnamed>")
+                       << "' has " << primsSize << " primitives. "
+                       << "ExpandedIndices registration only supports single-primitive meshes. "
+                       << "Triangle filtering may not work correctly for this mesh." << io::endl;
+            }
+
+            if (primsSize == 1) {
+                auto& expandedIndices = getExpandedIndices(meshIndex, 0);
+                if (!expandedIndices.empty()) {
+                    registerExpandedIndices(entity,
+                        expandedIndices.data(),
+                        expandedIndices.size());
+                }
+            }
+        }
+    }
+
+    pendingRegistrations.clear();
+
+    // Free expandedIndices from meshCache now that all entities are registered
+    for (size_t i = 0; i < meshCacheSize; i++) {
+        const size_t primsSize = getPrimsSize(i);
+        for (size_t j = 0; j < primsSize; j++) {
+            auto& expandedIndices = getExpandedIndices(i, j);
+            expandedIndices.clear();
+            expandedIndices.shrink_to_fit();
+        }
+    }
+
+    logMemoryUsage();
+    return allSucceeded;
+}
+
 bool PickingRegistry::registerMesh(const Entity entity, const cgltf_mesh* mesh) {
     if (!mesh) {
         slog.w << "PickingRegistry: NULL mesh pointer for entity " << entity.getId() << io::endl;

--- a/libs/gltfio/src/PickingRegistry.cpp
+++ b/libs/gltfio/src/PickingRegistry.cpp
@@ -125,6 +125,7 @@ bool PickingRegistry::commitRegistrations(
     }
 
     pendingRegistrations.clear();
+    decltype(pendingRegistrations){}.swap(pendingRegistrations);
 
     // Free expandedIndices from meshCache now that all entities are registered
     for (size_t i = 0; i < meshCacheSize; i++) {

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -480,57 +480,20 @@ bool ResourceLoader::loadResources(FFilamentAsset* asset, bool async) {
         ResourceLoaderExtended::loadResources(slots, pImpl->mEngine, asset->mBufferObjects);
     }
 
-    // Register meshes for picking - this works for both standard and extended paths
-    // For standard path: buffers were just loaded above via loadCgltfBuffers()
-    // For extended path: buffers were loaded earlier in AssetLoaderExtended::createPrimitive()
-    // In both cases, buffer->data is now valid and we can read vertex positions
-    for (const auto& [entity, mesh] : asset->mPendingMeshRegistrations) {
-        asset->mPickingRegistry.registerMesh(entity, mesh);
-
-        // For AssetLoaderExtended: also register expanded indices if available
-        // This allows triangle filtering to work correctly with expanded vertex buffers
-        // NOTE: Multiple entities can share the same primitive (via mMeshCache).
-        // Since assign() copies the data, all entities will copy from the shared expandedIndices.
-        // We clear all primitives after the loop to avoid clearing while other entities still need it.
-        const cgltf_size meshIndex = mesh - gltf->meshes;
-        if (meshIndex < asset->mMeshCache.size()) {
-            const auto& prims = asset->mMeshCache[meshIndex];
-
-            // Warn if mesh has multiple primitives - we only handle single-primitive meshes
-            if (prims.size() > 1) {
-                slog.w << "Mesh '" << (mesh->name ? mesh->name : "<unnamed>")
-                       << "' has " << prims.size() << " primitives. "
-                       << "ExpandedIndices registration only supports single-primitive meshes. "
-                       << "Triangle filtering may not work correctly for this mesh." << io::endl;
+    if (const auto pickingRegistry = asset->getPickingRegistry()) {
+        pickingRegistry->commitRegistrations(
+            /* gltfMeshes */ gltf->meshes,
+            /* meshCacheSize */ asset->mMeshCache.size(),
+            /* getPrimsSize */
+            [asset](const size_t meshIndex) -> size_t {
+                return asset->mMeshCache[meshIndex].size();
+            },
+            /* getExpandedIndices */
+            [asset](const size_t meshIndex, const size_t primIndex) -> std::vector<uint32_t>& {
+                return asset->mMeshCache[meshIndex][primIndex].expandedIndices;
             }
-
-            // For simplicity, we only handle single-primitive meshes for now
-            // Multi-primitive meshes would need more complex index concatenation
-            // When we merge meshes using gltfpack, it creates separate mesh for each primitive,
-            // so this is not a problem in practice.
-            // https://github.com/Fieldwire/meshoptimizer/blob/34ea6b0f1041794b37fd33a512999c44a3704470/gltf/parsegltf.cpp#L197
-            if (prims.size() == 1 && !prims[0].expandedIndices.empty()) {
-                asset->mPickingRegistry.registerExpandedIndices(entity,
-                    prims[0].expandedIndices.data(),
-                    prims[0].expandedIndices.size());
-            }
-        }
+        );
     }
-    asset->mPendingMeshRegistrations.clear();
-
-    // Clear expandedIndices from all primitives in mMeshCache to save memory
-    // Now that all entities have been registered, we can safely free this temporary data
-    for (auto& primList : asset->mMeshCache) {
-        for (auto& prim : primList) {
-            if (!prim.expandedIndices.empty()) {
-                prim.expandedIndices.clear();
-                prim.expandedIndices.shrink_to_fit();
-            }
-        }
-    }
-
-    // Log memory usage of PickingRegistry after all entities are registered
-    asset->mPickingRegistry.logMemoryUsage();
 
     createSkins(gltf, pImpl->mNormalizeSkinningWeights, asset->mSkins);
 

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -826,6 +826,7 @@ int main(int argc, char** argv) {
         // Use the below code to load the gltf file without normals
         AssetConfigurationExtended ext = {
             .gltfPath = filename.c_str(),
+            .trianglePickingEnabled = true,
         };
         AssetConfiguration config = {
             .engine = engine,


### PR DESCRIPTION
https://fieldwire.atlassian.net/browse/ME-6600


Makes BVH construction opt-in at asset load time via a new `trianglePickingEnabled` flag. Previously, the BVH was always built for every loaded asset. On large models (150K+ objects), this caused OOM crashes on Pixel-class devices.

When `trianglePickingEnabled = false`, `getPickingRegistry()` returns `nullptr` and all downstream picking code — mesh enqueueing, BVH build, expanded-indices registration, memory logging — is completely skipped. A fast path in `nFwCreateAssetLoader` falls through to the standard upstream `nCreateAssetLoader` when neither flag is set.

Also refactors `PickingRegistry` to own its pending-registration queue: `pendingRegistrations` moves off `FFilamentAsset` and the inline ~55-line registration loop in `ResourceLoader.cpp` is replaced by a single `commitRegistrations()` call.

**Changed files:**

| File | What Changed |
|------|-------------|
| `libs/gltfio/include/gltfio/AssetLoader.h` | `bool trianglePickingEnabled = false` added to `AssetConfigurationExtended` |
| `libs/gltfio/include/gltfio/PickingRegistry.h` | `enqueueMesh()` + `commitRegistrations()` API; `pendingRegistrations` queue moved here from `FFilamentAsset` |
| `libs/gltfio/src/PickingRegistry.cpp` | `commitRegistrations()` impl — BVH build, expanded-indices registration, queue clear, memory free, memory log |
| `libs/gltfio/src/FFilamentAsset.h` | `mTrianglePickingEnabled` field; `getPickingRegistry()` returns `nullptr` when false; `mPendingMeshRegistrations` removed |
| `libs/gltfio/src/FilamentAsset.cpp` | `~FFilamentAsset` guards `registry.clear()` on `getPickingRegistry()` |
| `libs/gltfio/src/AssetLoader.cpp` | Reads `trianglePickingEnabled` from config; passes to `FFilamentAsset`; `createRenderable` uses `enqueueMesh()`; `expandedIndices` population gated on `mTrianglePickingEnabled` |
| `libs/gltfio/src/ResourceLoader.cpp` | ~55-line inline registration loop replaced with `pickingRegistry->commitRegistrations(...)` |
| `android/gltfio-android/src/main/cpp/AssetLoader.cpp` | `nCreateAssetLoaderExtended` → `nFwCreateAssetLoader`; `static_cast` → `reinterpret_cast`; `filePath` param removed |
| `.../AssetLoader.java` | New constructor `(engine, provider, entities, generateNormals, trianglePickingEnabled)`; `nCreateAssetLoaderExtended` binding removed |
| `.../ModelViewer.kt` | Updated to new constructor: `AssetLoader(..., false, true)` |

## Notes:
- `nCreateAssetLoader` (upstream standard path) is untouched.
- `nCreateAssetLoaderExtended` removed — had no external callers.
- `filePath` removed from JNI path — vestigial on Android (`GLTFIO_USE_FILESYSTEM=0`)
- `generateNormals` replaces the old `filePath != null` signal for opting into the extended loader. Previously, `nCreateAssetLoaderExtended` was called with a non-null `filePath` to get normal generation; `filePath = null` fell through to the standard loader. The new flag makes that intent explicit. `AssetLoaderExtended` still generates normals unconditionally — the flag is not yet passed into `AssetConfigurationExtended`, so it only affects fast-path selection. No behaviour change from the caller's perspective.
- `expandedIndices` population is gated on `mTrianglePickingEnabled` in `AssetLoader.cpp`. When picking is disabled the buffer is never allocated, so no cleanup is needed in `ResourceLoader.cpp`.
- `mPickingRegistry` - When disabled, its `unordered_map` and `vector` are default-constructed and empty (~48 bytes total), which is negligible next to the rest of `FFilamentAsset`. BVH data only exists in the map when meshes are actively registered, so there is no hidden cost.


## Screenshots
no visual changes

## Testing Notes
### What did you do to test this PR?
- Android build (arm64-v8a) — `nFwCreateAssetLoader` compiles cleanly with `reinterpret_cast`
- macOS native release build completed successfully
- Android release build (arm64-v8a + armeabi-v7a) completed successfully
- AARs copied to `fieldwire_android`
- Symbol extraction completed successfully
- Smoke test: model loads; triangle picking functional when `trianglePickingEnabled = true`
- Verified no picking code runs when `trianglePickingEnabled = false` (fast-path + null registry guard)

### Should QA/Product do something special to test this PR?
- No special steps — this is a Filament-side change; QA validation happens via the Android app integration in a follow-up PR
