### PR TITLE
Extend extended loader to avoid state leakage across asset parses

### DIFF
--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -243,6 +243,9 @@ if (FILAMENT_BUILD_TESTING)
 
     add_test_gltf("third_party/models/AnimatedMorphCube/AnimatedMorphCube.glb" "AnimatedMorphCube.glb")
     add_test_gltf("third_party/models/DamagedHelmet/DamagedHelmetWebp.glb" "DamagedHelmetWebp.glb")
+    add_test_gltf("third_party/models/AnimatedTriangle/AnimatedTriangle.gltf" "AnimatedTriangle.gltf")
+    add_test_gltf("third_party/models/AnimatedTriangle/simpleTriangle.bin" "simpleTriangle.bin")
+    add_test_gltf("third_party/models/AnimatedTriangle/animation.bin" "animation.bin")
 
     add_custom_target(test_gltfio_files DEPENDS ${GLTF_TEST_FILES})
 

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -406,6 +406,12 @@ FFilamentAsset* FAssetLoader::createInstancedAsset(const uint8_t* bytes, uint32_
         return nullptr;
     }
 
+    if (mLoaderExtended) {
+        // The extended loader can outlive a single asset, so clear its per-asset buffer-load
+        // bookkeeping before starting a fresh parse.
+        mLoaderExtended->beginAssetLoad();
+    }
+
     FFilamentAsset* fAsset = createRootAsset(sourceAsset);
     if (mError) {
         delete fAsset;

--- a/libs/gltfio/src/extended/AssetLoaderExtended.cpp
+++ b/libs/gltfio/src/extended/AssetLoaderExtended.cpp
@@ -525,11 +525,13 @@ bool AssetLoaderExtended::createPrimitive(Input* input, Output* out,
                 slotCount++};
     }
 
+    // Only do the expensive buffer load and meshopt decode once per asset parse for the
+    // configured glTF base path. beginAssetLoad() clears this flag before each new parse.
     if (!mCgltfBuffersLoaded) {
-        mCgltfBuffersLoaded = utility::loadCgltfBuffers(gltf, mGltfPath.c_str(), mUriDataCache);
-        if (!mCgltfBuffersLoaded) {
+        if (const bool loadSuccessful = utility::loadCgltfBuffers(gltf, mGltfPath.c_str(), mUriDataCache); !loadSuccessful) {
             return false;
         }
+        mCgltfBuffersLoaded = true;
         utility::decodeMeshoptCompression(gltf);
     }
 

--- a/libs/gltfio/src/extended/AssetLoaderExtended.h
+++ b/libs/gltfio/src/extended/AssetLoaderExtended.h
@@ -70,7 +70,8 @@ struct AssetLoaderExtended {
         : mEngine(engine),
           mGltfPath(config.gltfPath),
           mMaterials(materials),
-          mUriDataCache(std::make_shared<UriDataCache>()) {}
+          mUriDataCache(std::make_shared<UriDataCache>()),
+          mCgltfBuffersLoaded(false) {}
 
     ~AssetLoaderExtended() = default;
 

--- a/libs/gltfio/src/extended/AssetLoaderExtended.h
+++ b/libs/gltfio/src/extended/AssetLoaderExtended.h
@@ -70,10 +70,14 @@ struct AssetLoaderExtended {
         : mEngine(engine),
           mGltfPath(config.gltfPath),
           mMaterials(materials),
-          mUriDataCache(std::make_shared<UriDataCache>()),
-          mCgltfBuffersLoaded(false) {}
+          mUriDataCache(std::make_shared<UriDataCache>()) {}
 
     ~AssetLoaderExtended() = default;
+
+    // Reset per-asset buffer-load bookkeeping before parsing a new glTF.
+    void beginAssetLoad() noexcept {
+        mCgltfBuffersLoaded = false;
+    }
 
     bool createPrimitive(Input* input, Output* out, std::vector<BufferSlot>& outSlots);
 
@@ -84,7 +88,9 @@ private:
     std::string mGltfPath;
     MaterialProvider& mMaterials;
     UriDataCacheHandle mUriDataCache;
-    bool mCgltfBuffersLoaded;
+
+    // Track whether cgltf buffer loading has already run for the current asset parse.
+    bool mCgltfBuffersLoaded = false;
 };
 
 } // namespace filament::gltfio

--- a/libs/gltfio/test/gltfio_test.cpp
+++ b/libs/gltfio/test/gltfio_test.cpp
@@ -45,10 +45,33 @@ using namespace utils;
 
 char const* ANIMATED_MORPH_CUBE_GLB = "AnimatedMorphCube.glb";
 char const* DAMAGED_HELMET_WEBP_GLB = "DamagedHelmetWebp.glb";
+char const* ANIMATED_TRIANGLE_GLTF = "AnimatedTriangle.gltf";
 
 static std::ifstream::pos_type getFileSize(const char* filename) {
     std::ifstream in(filename, std::ifstream::ate | std::ifstream::binary);
     return in.tellg();
+}
+
+static std::vector<uint8_t> readFile(const Path& filename) {
+    std::ifstream in(filename.c_str(), std::ifstream::binary | std::ifstream::ate);
+    if (!in.is_open()) {
+        ADD_FAILURE() << "Unable to open " << filename;
+        return {};
+    }
+
+    std::ifstream::pos_type const fileSize = in.tellg();
+    if (fileSize <= 0) {
+        ADD_FAILURE() << "Invalid file size for " << filename << ": " << fileSize;
+        return {};
+    }
+
+    std::vector<uint8_t> buffer(static_cast<size_t>(fileSize));
+    in.seekg(0, std::ifstream::beg);
+    if (!in.read((char*) buffer.data(), static_cast<std::streamsize>(buffer.size()))) {
+        ADD_FAILURE() << "Unable to read " << filename;
+        return {};
+    }
+    return buffer;
 }
 
 class glTFData {
@@ -261,6 +284,41 @@ TEST_F(glTFIOTest, DamagedHelmetWebpMaterials) {
     EXPECT_TRUE(mData[DAMAGED_HELMET_WEBP_GLB]->mWebpDecoder == nullptr);
     EXPECT_EQ(mEngine->getTextureCount(), 3);    
 #endif
+}
+
+TEST_F(glTFIOTest, ExtendedLoaderRepeatedParsesReuseSameLoader) {
+    ASSERT_TRUE(AssetConfigurationExtended::isSupported());
+
+    Path const gltfFile = Path::getCurrentExecutable().getParent() + Path(ANIMATED_TRIANGLE_GLTF);
+    Path const absoluteGltfFile = gltfFile.getAbsolutePath();
+    std::vector<uint8_t> const buffer = readFile(gltfFile);
+    ASSERT_FALSE(buffer.empty());
+
+    AssetConfigurationExtended ext = {
+            .gltfPath = absoluteGltfFile.c_str(),
+    };
+    AssetConfiguration config = {
+            .engine = mEngine,
+            .materials = mMaterialProvider,
+            .names = mNameManager,
+            .ext = &ext,
+    };
+
+    AssetLoader* loader = AssetLoader::create(config);
+    ASSERT_NE(loader, nullptr);
+
+    FilamentAsset* firstAsset = loader->createAsset(buffer.data(), buffer.size());
+    ASSERT_NE(firstAsset, nullptr);
+    EXPECT_GT(firstAsset->getRenderableEntityCount(), 0u);
+    const size_t firstRenderableCount = firstAsset->getRenderableEntityCount();
+    loader->destroyAsset(firstAsset);
+
+    FilamentAsset* secondAsset = loader->createAsset(buffer.data(), buffer.size());
+    ASSERT_NE(secondAsset, nullptr);
+    EXPECT_EQ(secondAsset->getRenderableEntityCount(), firstRenderableCount);
+    loader->destroyAsset(secondAsset);
+
+    AssetLoader::destroy(&loader);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
https://fieldwire.atlassian.net/browse/ME-6870

Resets extended-loader parse state so later asset parses do not reuse stale loaded-state.

This updates the extended loader to clear the loaded-state for buffer/decode work before a new asset parse begins, while still preserving the intended once-per-asset behavior within a single parse. The goal is to prevent later asset loads on the same loader from incorrectly skipping required work because state from an earlier parse was left behind.

This change is limited to the extended-loader state lifetime issue. It does not add Android-side multi-model integration, sample or harness support, or broader federated BIM behavior. It also does not change placement, framing, picking, transforms, or app lifecycle handling.

update: previously was using a set to track load. current implementation just keeps the boolean and resets it on each new asset

## Screenshots
N/A

## Testing Notes
### What did you do to test this PR?
- added regression coverage for repeated parses on the same extended loader
- built and ran `test_gltfio`; the new repeated-parse test passed
- ran local pre-Android multi-model validation using uncommitted `gltf_viewer` harness-only changes outside this PR
- confirmed multiple models rendered in one scene in the local viewer harness
- built new filament AARs from this change and validated them through the existing Android POC multi-model path
- confirmed rendering, navigation, and picking worked in the Android POC
- observed no discernable performance regression versus the POC filament changes during this validation
